### PR TITLE
Fix outside migration create tables

### DIFF
--- a/web_app/alembic/env.py
+++ b/web_app/alembic/env.py
@@ -6,7 +6,7 @@ from sqlalchemy import pool
 from alembic import context
 
 from web_app.db.database import SQLALCHEMY_DATABASE_URL
-from web_app.db.models import Base, User
+from web_app.db.models import Base
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/web_app/api/main.py
+++ b/web_app/api/main.py
@@ -5,14 +5,12 @@ from fastapi import FastAPI
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.middleware.cors import CORSMiddleware
 
-from web_app.db.database import Base, engine
 from web_app.api.dashboard import router as dashboard_router
 from web_app.api.position import router as position_router
 from web_app.api.user import router as user_router
 
 app = FastAPI()
 
-Base.metadata.create_all(bind=engine)
 # Set up the templates directory
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
Delete call function `Base.metadata.create_all(bind=engine).`