### PR TITLE
Fix/api error handling

### DIFF
--- a/web_app/api/position.py
+++ b/web_app/api/position.py
@@ -78,7 +78,7 @@ async def close_position(position_id: str) -> str:
     :raises: HTTPException :return: Dict containing status code and detail
     """
     if position_id is None or position_id == "undefined":
-        raise HTTPException(status_code=400, detail="Invalid position_id provided")
+        raise HTTPException(status_code=404, detail="Invalid position_id provided")
 
     position_status = position_db_connector.close_position(position_id)
     return position_status
@@ -93,7 +93,7 @@ async def open_position(position_id: str) -> str:
     :raises: HTTPException :return: Dict containing status code and detail
     """
     if not position_id:
-        raise HTTPException(status_code=400, detail="Position ID is required")
+        raise HTTPException(status_code=404, detail="Position not found")
 
     position_status = position_db_connector.open_position(position_id)
     return position_status

--- a/web_app/api/position.py
+++ b/web_app/api/position.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException
 
 from web_app.api.serializers.transaction import (
     LoopLiquidityData,
@@ -54,9 +54,10 @@ async def get_repay_data(
     :param supply_token: Supply token address
     :param wallet_id: Wallet ID
     :return: Dict containing the repay transaction data
+    :raises: HTTPException :return: Dict containing status code and detail
     """
     if not wallet_id:
-        raise ValueError("Wallet ID is required")
+        raise HTTPException(status_code=400, detail="Wallet ID is required")
 
     contract_address = position_db_connector.get_contract_address_by_wallet_id(
         wallet_id
@@ -74,9 +75,10 @@ async def close_position(position_id: str) -> str:
     Close a position.
     :param position_id: contract address
     :return: str
+    :raises: HTTPException :return: Dict containing status code and detail
     """
-    if position_id is None or position_id == 'undefined':
-        raise ValueError("Invalid position_id provided")
+    if position_id is None or position_id == "undefined":
+        raise HTTPException(status_code=400, detail="Invalid position_id provided")
 
     position_status = position_db_connector.close_position(position_id)
     return position_status
@@ -88,9 +90,10 @@ async def open_position(position_id: str) -> str:
     Open a position.
     :param position_id: contract address
     :return: str
+    :raises: HTTPException :return: Dict containing status code and detail
     """
     if not position_id:
-        raise ValueError("Position ID is required")
+        raise HTTPException(status_code=400, detail="Position ID is required")
 
     position_status = position_db_connector.open_position(position_id)
     return position_status

--- a/web_app/api/position.py
+++ b/web_app/api/position.py
@@ -57,7 +57,7 @@ async def get_repay_data(
     :raises: HTTPException :return: Dict containing status code and detail
     """
     if not wallet_id:
-        raise HTTPException(status_code=400, detail="Wallet ID is required")
+        raise HTTPException(status_code=404, detail="Wallet not found")
 
     contract_address = position_db_connector.get_contract_address_by_wallet_id(
         wallet_id
@@ -78,7 +78,7 @@ async def close_position(position_id: str) -> str:
     :raises: HTTPException :return: Dict containing status code and detail
     """
     if position_id is None or position_id == "undefined":
-        raise HTTPException(status_code=404, detail="Invalid position_id provided")
+        raise HTTPException(status_code=404, detail="Position not Found")
 
     position_status = position_db_connector.close_position(position_id)
     return position_status

--- a/web_app/api/user.py
+++ b/web_app/api/user.py
@@ -20,7 +20,6 @@ async def get_user_contract(wallet_id: str) -> int:
 
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-
     elif not user.is_contract_deployed:
         raise HTTPException(status_code=404, detail="Contract not deployed")
     else:

--- a/web_app/api/user.py
+++ b/web_app/api/user.py
@@ -8,7 +8,7 @@ user_db = UserDBConnector()
 
 
 @router.get("/api/get-user-contract")
-async def get_user_contract(wallet_id: str = Query(...)) -> int:
+async def get_user_contract(wallet_id: str) -> int:
     """
     Get the contract status of a user.
     :param wallet_id: wallet id

--- a/web_app/api/user.py
+++ b/web_app/api/user.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, HTTPException, Query
 from web_app.db.crud import UserDBConnector
 from web_app.api.serializers.transaction import UpdateUserContractRequest
 
@@ -8,15 +8,21 @@ user_db = UserDBConnector()
 
 
 @router.get("/api/get-user-contract")
-async def get_user_contract(wallet_id: str) -> int:
+async def get_user_contract(wallet_id: str = Query(...)) -> int:
     """
     Get the contract status of a user.
     :param wallet_id: wallet id
     :return: int
+    :raises: HTTPException :return: Dict containing status code and detail
     """
+
     user = user_db.get_user_by_wallet_id(wallet_id)
-    if user is None or not user.is_contract_deployed:
-        return 0
+
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    elif not user.is_contract_deployed:
+        raise HTTPException(status_code=404, detail="Contract not deployed")
     else:
         return user.deployed_transaction_hash
 


### PR DESCRIPTION
### Header
Adding error handling when updating a user and contract

### Change description
- Added error handling for the case when the user is not found.
- Added error handling for the case if the contract is not deployed.
- Added error handling for the case when the wallet_id  is not found.
- Added error handling for the case when the position_id is not found.

### Why
Previously, if the something required in parameters in function does not exist, `None` was returned or 0, which could confuse API users. This is now handled correctly, which improves the UX and makes debugging easier.

### How test
1. (/api/get-user-contract) Try to get user contract for an existing user - a successful response is expected.
2. (/api/get-user-contract) Try to get user contract for a non-existent user or user_contract_not_deployed - a 404 error with a corresponding message is expected.
3. (api/get-repay-data) Try to get repay_data for an existing wallet_id - a successful response is expected.
4. (api/get-repay-data) Try to get repay_data for a non existing wallet_id - a 404 error with a corresponding message is expected.
5. (/api/close-position) Try to get position_status for an existing position_id - a successful response is expected.
6. (/api/close-position) Try to get position_status for a non existing position_id - a 404 error with a corresponding message is expected.
7. (/api/open-position) Try to get position_status for an existing position_id - a successful response is expected.
8. (/api/open-position) Try to get position_status for a non existing position_id - a 404 error with a corresponding message is expected.

### Notes
Please check that your tests are up to date and running successfully.