### PR TITLE
fix: changed backend url typo error

### DIFF
--- a/frontend/test/constants.js
+++ b/frontend/test/constants.js
@@ -1,1 +1,1 @@
-export const mockBackendUrl = "http://127.0.0.1:8000";
+export const mockBackendUrl = "http://0.0.0.0:8000";


### PR DESCRIPTION
Changed the backend url due to previous typo error