### PR TITLE
feat: implement function to check health_ratio_level per wallet_id 

### DIFF
--- a/web_app/contract_tools/mixins/alert.py
+++ b/web_app/contract_tools/mixins/alert.py
@@ -1,0 +1,8 @@
+"""
+This module contains the alert mixin class.
+"""
+
+class AlertMixin:
+    """
+    Mixin class for alert related methods.
+    """

--- a/web_app/contract_tools/mixins/alert.py
+++ b/web_app/contract_tools/mixins/alert.py
@@ -7,6 +7,8 @@ from web_app.db.models import Status
 from web_app.contract_tools.mixins.dashboard import DashboardMixin
 from web_app.contract_tools.mixins.custom_exception import HealthRatioLevelLowException
 
+ALERT_THRESHOLD = 1.1
+
 class AlertMixin:
     """
     Mixin class for alert related methods.
@@ -20,10 +22,9 @@ class AlertMixin:
 
         users = UserDBConnector().get_all_users_with_opened_position()
 
-        if users:
-            for user in users:
-                zk_lend_position = DashboardMixin.get_zklend_position(user.contract_address)
+        for user in users:
+            zk_lend_position = DashboardMixin.get_zklend_position(user.contract_address)
 
-                health_ratio_level = zk_lend_position.health_ratio_level
-                if health_ratio_level < 1.1:
-                    raise HealthRatioLevelLowException(user.id, health_ratio_level)
+            health_ratio_level = zk_lend_position.health_ratio_level
+            if health_ratio_level < ALERT_THRESHOLD:
+                raise HealthRatioLevelLowException(user.id, health_ratio_level)

--- a/web_app/contract_tools/mixins/alert.py
+++ b/web_app/contract_tools/mixins/alert.py
@@ -1,8 +1,35 @@
 """
 This module contains the alert mixin class.
 """
+from typing import List
+from web_app.db.crud import UserDBConnector
+from web_app.contract_tools.mixins.dashboard import DashboardMixin
+
+class HealthRatioLevelLowException(Exception):
+    """
+    Exception raised when a user's health ratio level is lower than 1.1.
+    """
+    def __init__(self, user_id: int, health_ratio_level: float):
+        self.message = f"User {user_id} has a low health ratio level: {health_ratio_level}"
+        super().__init__(self.message)
 
 class AlertMixin:
     """
     Mixin class for alert related methods.
     """
+
+    def check_users_health_ratio_level(self) -> None:
+        """
+        Check the health ratio level for all users with an OPENED position.
+        If a user's health ratio level is lower than 1.1, raise a `HealthRatioLevelLowException`.
+        """
+
+        users = UserDBConnector().get_all_users()
+
+        if users:
+            for user in users:
+                zk_lend_position = DashboardMixin.get_zklend_position(user.contract_address)
+
+                health_ratio_level = zk_lend_position.health_ratio_level
+                if health_ratio_level < 1.1:
+                    raise HealthRatioLevelLowException(user.id, health_ratio_level)

--- a/web_app/contract_tools/mixins/alert.py
+++ b/web_app/contract_tools/mixins/alert.py
@@ -4,6 +4,23 @@ This module contains the alert mixin class.
 from typing import List
 from web_app.db.crud import UserDBConnector
 from web_app.contract_tools.mixins.dashboard import DashboardMixin
+from enum import Enum
+
+class Status(Enum):
+    """
+    Enum for the position status.
+    """
+    PENDING = "pending"
+    OPENED = "opened"
+    CLOSED = "closed"
+
+    @classmethod
+    def choices(cls):
+        """
+        Returns the list of status choices.
+        """
+        return [status.value for status in cls]
+
 
 class HealthRatioLevelLowException(Exception):
     """
@@ -28,8 +45,10 @@ class AlertMixin:
 
         if users:
             for user in users:
-                zk_lend_position = DashboardMixin.get_zklend_position(user.contract_address)
+                for position in user.positions:
+                    if position.status == Status.OPENED.value:
+                        zk_lend_position = DashboardMixin.get_zklend_position(user.contract_address)
 
-                health_ratio_level = zk_lend_position.health_ratio_level
-                if health_ratio_level < 1.1:
-                    raise HealthRatioLevelLowException(user.id, health_ratio_level)
+                        health_ratio_level = zk_lend_position.health_ratio_level
+                        if health_ratio_level < 1.1:
+                            raise HealthRatioLevelLowException(user.id, health_ratio_level)

--- a/web_app/contract_tools/mixins/custom_exception.py
+++ b/web_app/contract_tools/mixins/custom_exception.py
@@ -1,0 +1,10 @@
+"""
+    This module contains custom errors for the database
+"""
+class HealthRatioLevelLowException(Exception):
+    """
+    Exception raised when a user's health ratio level is lower than 1.1.
+    """
+    def __init__(self, user_id: int, health_ratio_level: float):
+        self.message = f"User {user_id} has a low health ratio level: {health_ratio_level}"
+        super().__init__(self.message)

--- a/web_app/db/crud.py
+++ b/web_app/db/crud.py
@@ -159,7 +159,7 @@ class UserDBConnector(DBConnector):
         Retrieve all users from the database with an OPENED position status.
         :return: List[User] | None
         """
-        return self.get_all_users_with_opened_position(User)
+        return self.get_all_users_with_opened_position(User, "position", "OPENED")
 
 
     def get_contract_address_by_wallet_id(self, wallet_id: str) -> str:

--- a/web_app/db/crud.py
+++ b/web_app/db/crud.py
@@ -140,14 +140,14 @@ class UserDBConnector(DBConnector):
         """
         with self.Session() as db:
             try:
-                positions = (
-                    db.query(Position)
+                users = (
+                    db.query(User)
+                    .join(Position, Position.user_id == User.id)
                     .filter(Position.status == Status.OPENED.value)
+                    .distinct()
                     .all()
                 )
-
-                user_ids = {position.user_id for position in positions}
-                return db.query(User).filter(User.id.in_(user_ids)).all()
+                return users
             except SQLAlchemyError as e:
                 logger.error(f"Error retrieving users with OPENED positions: {e}")
                 return []

--- a/web_app/db/crud.py
+++ b/web_app/db/crud.py
@@ -89,6 +89,22 @@ class DBConnector:
         finally:
             db.close()
 
+    def get_all_users_with_opened_position(
+        self, model: Type[ModelType] = None
+    ) -> list[ModelType] | None:
+        """
+        Retrieves all users with an OPENED position status from the database.
+        
+        :param model: type[Base] = None
+        :return: list[Base] | None
+        """
+        db = self.Session()
+        try:
+            return db.query(model).filter(model.position == 'OPENED').all()
+        finally:
+            db.close()
+
+
     def delete_object(self, model: Type[Base] = None, obj_id: uuid = None) -> None:
         """
         Delete an object by its ID from the database. Rolls back if the operation fails.
@@ -137,6 +153,14 @@ class UserDBConnector(DBConnector):
         :return: User | None
         """
         return self.get_object_by_field(User, "wallet_id", wallet_id)
+    
+    def get_all_users(self) -> List[User] | None:
+        """
+        Retrieve all users from the database with an OPENED position status.
+        :return: List[User] | None
+        """
+        return self.get_all_users_with_opened_position(User)
+
 
     def get_contract_address_by_wallet_id(self, wallet_id: str) -> str:
         """


### PR DESCRIPTION
## Overview
cloese issue [#199]
This PR implements the `AlertMixin` class and its associated functionality to check the health ratio level of users with an OPENED position status. If a user's health ratio level is lower than the required threshold of `1.1`, a custom exception `HealthRatioLevelLowException` is raised. The following changes are included:

- **AlertMixin Class**: Added the `check_users_health_ratio_level` method, which:
  - Fetches all users with an OPENED position.
  - Retrieves the user's position using `DashboardMixin`.
  - Checks the user's health ratio level, raising the `HealthRatioLevelLowException` if the ratio is below `1.1`.
  
- **UserDBConnector Class**: Added the `get_all_users_with_opened_position` method, which fetches all users with an OPENED position status from the database.

- **Custom Exception**: Added `HealthRatioLevelLowException` to raise when a user's health ratio level is below `1.1`.