### PR TITLE
feat(api): add endpoint to enable notifications for telegram users

### DIFF
--- a/web_app/api/user.py
+++ b/web_app/api/user.py
@@ -3,10 +3,10 @@ This module handles user-related API endpoints.
 """
 import logging
 from decimal import Decimal
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from web_app.contract_tools.mixins.dashboard import DashboardMixin
-from web_app.db.crud import PositionDBConnector, UserDBConnector
+from web_app.db.crud import PositionDBConnector, TelegramUserDBConnector, UserDBConnector
 from web_app.api.serializers.transaction import UpdateUserContractRequest
 from web_app.api.serializers.user import (
     CheckUserResponse,
@@ -18,6 +18,7 @@ from web_app.api.serializers.user import (
 
 logger = logging.getLogger(__name__)
 router = APIRouter()  # Initialize the router
+telegram_db = TelegramUserDBConnector()
 
 user_db = UserDBConnector()
 
@@ -217,3 +218,21 @@ async def get_stats() -> GetStatsResponse:
     except Exception as e:
         logger.error(f"Error in get_stats: {e}")
         raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+    
+@router.post("/allow-notification/{telegram_id}")
+async def allow_notification(
+    telegram_id: int,
+    telegram_db: TelegramUserDBConnector = Depends(lambda: TelegramUserDBConnector()),
+):
+    """Enable notifications for a specific telegram user"""
+    try:
+        user = telegram_db.allow_notification(telegram_id=telegram_id)
+        return {
+            "telegram_id": user.telegram_id,
+            "is_allowed_notification": user.is_allowed_notification,
+            "message": "Notifications enabled successfully"
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/web_app/db/crud.py
+++ b/web_app/db/crud.py
@@ -573,3 +573,31 @@ class TelegramUserDBConnector(DBConnector):
                     "is_allowed_notification": True
                 }
                 return self.create_telegram_user(user_data)
+            
+    def allow_notification(self, telegram_id: int) -> TelegramUser:
+        """
+        Update is_allowed_notification field to True for a specific telegram user
+        
+        Args:
+            telegram_id: Telegram user ID
+            
+        Returns:
+            Updated TelegramUser instance
+            
+        Raises:
+            SQLAlchemyError: If there's an error during the database operation
+        """ 
+        with self.Session() as session:
+            try:
+                user = session.query(TelegramUser).filter_by(telegram_id=telegram_id).first()
+                if not user:
+                    raise ValueError(f"User with telegram_id {telegram_id} not found")
+                
+                user.is_allowed_notification = True
+                session.commit()
+                session.refresh(user)
+                return user
+            except SQLAlchemyError as e:
+                session.rollback()
+                logging.error(f"Error allowing notification for user {telegram_id}: {str(e)}")
+                raise


### PR DESCRIPTION
- add `allow_notification` method in `TelegramUserDBConnector`
- import `TelegramUserDBConnector` in `user.py`
- add new endpoint `/allow-notification/{telegram_id}` to enable notifications for a specific telegram user

Adding test and will modify for pylint rating now

Draft for #204 