### PR TITLE
feat: create endpoint to check if user has already opened position 

### DIFF
--- a/web_app/api/user.py
+++ b/web_app/api/user.py
@@ -23,6 +23,27 @@ user_db = UserDBConnector()
 
 position_db = PositionDBConnector()
 
+@router.get(
+    "/api/has-user-opened-position",
+    tags=["Position Operations"],
+    summary="Check if user has opened position",
+    response_description="Returns true if the user has an opened position, false otherwise",
+)
+async def has_user_opened_position(wallet_id: str) -> dict:
+    """
+    Check if a user has any opened positions.
+    :param wallet_id: wallet id
+    :return: Dict containing boolean result
+    :raises: HTTPException
+    """
+    try:
+        has_position = position_db.has_opened_position(wallet_id)
+        return {"has_opened_position": has_position}
+    except ValueError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Invalid wallet ID format: {str(e)}"
+        )
 
 @router.get(
     "/api/get-user-contract",

--- a/web_app/db/crud.py
+++ b/web_app/db/crud.py
@@ -273,6 +273,32 @@ class PositionDBConnector(UserDBConnector):
                 logger.error(f"Failed to retrieve positions: {str(e)}")
                 return []
 
+    def has_opened_position(self, wallet_id: str) -> bool:
+        """
+        Checks if a user has any opened positions.
+        :param wallet_id: str
+        :return: bool
+        """
+        with self.Session() as db:
+            user = self._get_user_by_wallet_id(wallet_id)
+            if not user:
+                return False
+
+            try:
+                position_exists = db.query(
+                    db.query(Position)
+                    .filter(
+                        Position.user_id == user.id,
+                        Position.status == Status.OPENED.value,
+                    )
+                    .exists()
+                ).scalar()
+                return position_exists
+
+            except SQLAlchemyError as e:
+                logger.error(f"Failed to check for opened positions: {str(e)}")
+                return False
+
     def create_position(
         self, wallet_id: str, token_symbol: str, amount: str, multiplier: int
     ) -> Position:


### PR DESCRIPTION
## Add User Position Status Check Endpoint

### Changes Made
- Added new GET endpoint `/api/has-user-opened-position` to check user's position status
- Implemented CRUD method `has_opened_position` in PositionDBConnector
- Added boolean response for position status check

### Technical Details
- New endpoint accepts `wallet_id` as input parameter
- Returns simple boolean response: `true` if user has opened position, `false` otherwise
- Implements proper error handling for database queries

### Related Issue
Closes #210