### PR TITLE
fix test cases on FE

### DIFF
--- a/frontend/test/services/wallet.test.js
+++ b/frontend/test/services/wallet.test.js
@@ -119,14 +119,14 @@ describe('Wallet Services', () => {
           callContract: jest.fn().mockImplementation(({ contractAddress }) => {
             const balances = {
               [ETH_ADDRESS]: { result: ['1000000000000000000'] },
-              [USDC_ADDRESS]: { result: ['2000000000000000000'] },
+              [USDC_ADDRESS]: { result: ['2000000'] },
               [STRK_ADDRESS]: { result: ['3000000000000000000'] },
             };
             return balances[contractAddress];
           }),
         },
       };
-
+      
       connect.mockResolvedValue(mockStarknet);
 
       const balances = await getTokenBalances('0x123');


### PR DESCRIPTION
I like cherry.
TG: @mymiracle0118

I have fixed test cases on FE.

The comparison value for USDC in the unit test using jest was set incorrectly.
I re-set it considering that the decimal of USDC is 6.

I would appreciate it if you could confirm that it has been resolved.