### PR TITLE
Add user positions endpoint with tests

### DIFF
--- a/web_app/api/position.py
+++ b/web_app/api/position.py
@@ -16,6 +16,7 @@ from web_app.contract_tools.constants import (
 from web_app.api.serializers.position import TokenMultiplierResponse
 from web_app.contract_tools.mixins import DepositMixin, DashboardMixin, PositionMixin
 from web_app.db.crud import PositionDBConnector
+from web_app.api.serializers.position import UserPositionsListResponse
 
 router = APIRouter()  # Initialize the router
 position_db_connector = PositionDBConnector()  # Initialize the PositionDBConnector
@@ -168,3 +169,27 @@ async def open_position(position_id: str) -> str:
     current_prices = await DashboardMixin.get_current_prices()
     position_status = position_db_connector.open_position(position_id, current_prices)
     return position_status
+
+
+@router.get(
+    "/api/user-positions/{wallet_id}",
+    tags=["Position Operations"],
+    response_model=UserPositionsListResponse,
+    summary="Get all positions for a user",
+    response_description="Returns list of all positions for the given wallet ID",
+)
+async def get_user_positions(wallet_id: str) -> UserPositionsListResponse:
+    """
+    Get all positions for a specific user by their wallet ID.
+
+    ### Parameters:
+    - **wallet_id**: The wallet ID of the user
+
+    ### Returns:
+    List of all positions associated with the wallet ID
+    """
+    if not wallet_id:
+        raise HTTPException(status_code=400, detail="Wallet ID is required")
+        
+    positions = position_db_connector.get_positions_by_wallet_id(wallet_id)
+    return UserPositionsListResponse(positions=positions)

--- a/web_app/api/position.py
+++ b/web_app/api/position.py
@@ -181,12 +181,9 @@ async def open_position(position_id: str) -> str:
 async def get_user_positions(wallet_id: str) -> UserPositionsListResponse:
     """
     Get all positions for a specific user by their wallet ID.
-
-    ### Parameters:
-    - **wallet_id**: The wallet ID of the user
-
-    ### Returns:
-    List of all positions associated with the wallet ID
+    :param wallet_id: The wallet ID of the user
+    :return: UserPositionsListResponse containing list of positions
+    :raises: HTTPException: If wallet ID is empty or invalid
     """
     if not wallet_id:
         raise HTTPException(status_code=400, detail="Wallet ID is required")

--- a/web_app/api/serializers/position.py
+++ b/web_app/api/serializers/position.py
@@ -3,6 +3,8 @@ This module defines the serializers for the position data.
 """
 
 from pydantic import BaseModel, field_validator
+from datetime import datetime
+from typing import List
 
 
 class PositionFormData(BaseModel):
@@ -55,3 +57,24 @@ class TokenMultiplierResponse(BaseModel):
         schema_extra = {
             "example": {"multipliers": {"ETH": 5.0, "STRK": 2.5, "USDC": 5.0}}
         }
+
+
+class UserPositionResponse(BaseModel):
+    """
+    Represents a single position in the user's position list.
+    """
+    id: str
+    token_symbol: str
+    amount: str
+    multiplier: float
+    status: str
+    created_at: datetime
+    start_price: float
+    is_liquidated: bool
+
+
+class UserPositionsListResponse(BaseModel):
+    """
+    Response model for list of user positions
+    """
+    positions: List[UserPositionResponse]

--- a/web_app/api/serializers/position.py
+++ b/web_app/api/serializers/position.py
@@ -4,7 +4,7 @@ This module defines the serializers for the position data.
 
 from pydantic import BaseModel, field_validator
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 
 class PositionFormData(BaseModel):
@@ -71,10 +71,11 @@ class UserPositionResponse(BaseModel):
     created_at: datetime
     start_price: float
     is_liquidated: bool
+    datetime_liquidation: Optional[datetime] = None
 
 
 class UserPositionsListResponse(BaseModel):
     """
-    Response model for list of user positions
+    Response model for list of user positions.
     """
-    positions: List[UserPositionResponse]
+    List[UserPositionResponse]


### PR DESCRIPTION
## Changes
- Add GET `/api/user-positions/{wallet_id}` endpoint to fetch all positions for a user
- Create response models `UserPositionResponse` and `UserPositionsListResponse`
- Implement `get_positions_by_wallet_id` in PositionDBConnector
- Add test cases for success and error scenarios

## Testing
- Added unit tests for:
  - Successful position retrieval
  - Empty wallet ID handling
  - No positions case
  - Invalid wallet ID case

Related Issues
Closes #351 