### PR TITLE
Feat: Add pagination to position history endpoint

### DIFF
--- a/web_app/api/dashboard.py
+++ b/web_app/api/dashboard.py
@@ -3,12 +3,13 @@ This module handles dashboard-related API endpoints.
 """
 
 import collections
+from decimal import Decimal, DivisionByZero
 
 from fastapi import APIRouter
+
 from web_app.api.serializers.dashboard import DashboardResponse
 from web_app.contract_tools.mixins import DashboardMixin, HealthRatioMixin
 from web_app.db.crud import PositionDBConnector
-from decimal import Decimal, DivisionByZero
 
 router = APIRouter()
 position_db_connector = PositionDBConnector()
@@ -40,18 +41,21 @@ async def get_dashboard(wallet_id: str) -> DashboardResponse:
         wallet_id
     )
     default_dashboard_response = DashboardResponse(
-            health_ratio="0",
-            multipliers={},
-            start_dates={},
-            current_sum=0,
-            start_sum=0,
-            borrowed="0",
-            balance="0",
-        )
+        health_ratio="0",
+        multipliers={},
+        start_dates={},
+        current_sum=0,
+        start_sum=0,
+        borrowed="0",
+        balance="0",
+    )
     if not contract_address:
         return default_dashboard_response
 
-    opened_positions = position_db_connector.get_positions_by_wallet_id(wallet_id)
+    # Fetching first 10 positions at the moment
+    opened_positions = position_db_connector.get_positions_by_wallet_id(
+        wallet_id, 0, 10
+    )
 
     # At the moment, we only support one position per wallet
     first_opened_position = (

--- a/web_app/api/position.py
+++ b/web_app/api/position.py
@@ -5,6 +5,7 @@ This module handles position-related API endpoints.
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
+
 from web_app.api.serializers.position import (
     PositionFormData,
     TokenMultiplierResponse,
@@ -227,10 +228,7 @@ async def get_user_positions(wallet_id: str, start: Optional[int] = None) -> lis
     if not wallet_id:
         raise HTTPException(status_code=400, detail="Wallet ID is required")
 
-    if start is not None:
-        start_index = max(0, start)
-    else:
-        start_index = 0
+    start_index = max(0, start) if start is not None else 0
 
     positions = position_db_connector.get_positions_by_wallet_id(
         wallet_id, start_index, PAGINATION_STEP

--- a/web_app/db/crud/position.py
+++ b/web_app/db/crud/position.py
@@ -59,11 +59,18 @@ class PositionDBConnector(UserDBConnector):
         """
         return self.get_user_by_wallet_id(wallet_id)
 
-    def get_positions_by_wallet_id(self, wallet_id: str) -> list:
+    def get_positions_by_wallet_id(
+        self,
+        wallet_id: str,
+        start: int,
+        limit: int
+    ) -> list:
         """
-        Retrieves all positions for a user by their wallet ID
+        Retrieves paginated positions for a user by their wallet ID
         and returns them as a list of dictionaries.
         :param wallet_id: str
+        :param start: starting index for pagination
+        :param limit: number of records to return
         :return: list of dict
         """
         with self.Session() as db:
@@ -78,6 +85,8 @@ class PositionDBConnector(UserDBConnector):
                         Position.user_id == user.id,
                         Position.status == Status.OPENED.value,
                     )
+                    .offset(start)
+                    .limit(limit)
                     .all()
                 )
                 # Convert positions to a list of dictionaries
@@ -288,19 +297,19 @@ class PositionDBConnector(UserDBConnector):
             logger.error(f"Error while saving current_price for position: {e}")
 
     def save_transaction(
-        self, 
-        position_id: uuid.UUID, 
-        status: str, 
+        self,
+        position_id: uuid.UUID,
+        status: str,
         transaction_hash: str
     ) -> bool:
         """
         Creates a new transaction record associated with a position.
-        
+
         Args:
             position_id: UUID of the position
             status: Transaction status (opened/closed)
             transaction_hash: Blockchain transaction hash
-            
+
         Returns:
             Transaction object if successful, None if failed
         """

--- a/web_app/db/crud/position.py
+++ b/web_app/db/crud/position.py
@@ -10,6 +10,7 @@ from typing import TypeVar
 
 from sqlalchemy import Numeric, cast, func
 from sqlalchemy.exc import SQLAlchemyError
+
 from web_app.db.models import Base, Position, Status, Transaction, User
 
 from .user import UserDBConnector
@@ -179,7 +180,7 @@ class PositionDBConnector(UserDBConnector):
         :param wallet_id: wallet ID
         :return: Position ID
         """
-        position = self.get_positions_by_wallet_id(wallet_id)
+        position = self.get_positions_by_wallet_id(wallet_id, 0, 1)
         if position:
             return position[0]["id"]
         return None

--- a/web_app/db/crud/position.py
+++ b/web_app/db/crud/position.py
@@ -10,9 +10,9 @@ from typing import TypeVar
 
 from sqlalchemy import Numeric, cast, func
 from sqlalchemy.exc import SQLAlchemyError
+from web_app.db.models import Base, Position, Status, Transaction, User
 
 from .user import UserDBConnector
-from web_app.db.models import Base, Position, Status, User, Transaction
 
 logger = logging.getLogger(__name__)
 ModelType = TypeVar("ModelType", bound=Base)
@@ -60,10 +60,7 @@ class PositionDBConnector(UserDBConnector):
         return self.get_user_by_wallet_id(wallet_id)
 
     def get_positions_by_wallet_id(
-        self,
-        wallet_id: str,
-        start: int,
-        limit: int
+        self, wallet_id: str, start: int, limit: int
     ) -> list:
         """
         Retrieves paginated positions for a user by their wallet ID
@@ -245,9 +242,7 @@ class PositionDBConnector(UserDBConnector):
         """
         with self.Session() as db:
             result = (
-                db.query(
-                    User.contract_address, Position.id, Position.token_symbol
-                )
+                db.query(User.contract_address, Position.id, Position.token_symbol)
                 .join(Position, Position.user_id == User.id)
                 .filter(User.wallet_id == wallet_id)
                 .first()
@@ -297,10 +292,7 @@ class PositionDBConnector(UserDBConnector):
             logger.error(f"Error while saving current_price for position: {e}")
 
     def save_transaction(
-        self,
-        position_id: uuid.UUID,
-        status: str,
-        transaction_hash: str
+        self, position_id: uuid.UUID, status: str, transaction_hash: str
     ) -> bool:
         """
         Creates a new transaction record associated with a position.
@@ -317,7 +309,7 @@ class PositionDBConnector(UserDBConnector):
             transaction = Transaction(
                 position_id=position_id,
                 status=status,
-                transaction_hash=transaction_hash
+                transaction_hash=transaction_hash,
             )
             return self.write_to_db(transaction)
         except SQLAlchemyError as e:

--- a/web_app/test_integration/test_close_position.py
+++ b/web_app/test_integration/test_close_position.py
@@ -7,8 +7,9 @@ from datetime import datetime
 from typing import Any, Dict
 
 import pytest
+
 from web_app.contract_tools.mixins.dashboard import DashboardMixin
-from web_app.db.crud import PositionDBConnector, UserDBConnector, AirDropDBConnector
+from web_app.db.crud import AirDropDBConnector, PositionDBConnector, UserDBConnector
 from web_app.db.models import Status
 
 user_db = UserDBConnector()
@@ -106,5 +107,5 @@ class TestPositionClose:
         user = position_db.get_user_by_wallet_id(wallet_id)
         airdrop.delete_all_users_airdrop(user.id)
         position_db.delete_position(position)
-        if not position_db.get_positions_by_wallet_id(wallet_id):
+        if not position_db.get_positions_by_wallet_id(wallet_id, 0, 1):
             position_db.delete_user_by_wallet_id(wallet_id)

--- a/web_app/tests/db/test_PositionDBConnector.py
+++ b/web_app/tests/db/test_PositionDBConnector.py
@@ -72,7 +72,9 @@ def test_get_positions_by_wallet_id_success(
 
     mock_position_db_connector.get_positions_by_wallet_id.return_value = [position_dict]
 
-    positions = mock_position_db_connector.get_positions_by_wallet_id("test_wallet_id")
+    positions = mock_position_db_connector.get_positions_by_wallet_id(
+        "test_wallet_id", 0, 1
+    )
 
     assert len(positions) == 1
     assert positions[0]["id"] == str(sample_position.id)
@@ -272,7 +274,7 @@ def test_get_positions_by_wallet_id_no_user(mock_position_db_connector):
     mock_position_db_connector.get_positions_by_wallet_id.return_value = []
 
     positions = mock_position_db_connector.get_positions_by_wallet_id(
-        "nonexistent_wallet"
+        "nonexistent_wallet", 0, 1
     )
 
     assert positions == []
@@ -282,7 +284,9 @@ def test_get_positions_by_wallet_id_db_error(mock_position_db_connector, sample_
     """Test handling database error when retrieving positions."""
     mock_position_db_connector._get_user_by_wallet_id.return_value = sample_user
 
-    positions = mock_position_db_connector.get_positions_by_wallet_id("test_wallet_id")
+    positions = mock_position_db_connector.get_positions_by_wallet_id(
+        "test_wallet_id", 0, 1
+    )
 
     assert positions == []
 
@@ -328,7 +332,9 @@ def test_get_position_id_by_wallet_id_no_positions(
     mock_position_db_connector.get_positions_by_wallet_id.return_value = []
     mock_position_db_connector.get_position_id_by_wallet_id.return_value = None
 
-    result = mock_position_db_connector.get_position_id_by_wallet_id("test_wallet_id")
+    result = mock_position_db_connector.get_position_id_by_wallet_id(
+        "test_wallet_id", 0, 1
+    )
 
     assert result is None
 


### PR DESCRIPTION
Changes include:
- Constant of PAGINATION_STEP is added with the value of 10
- `get_user_positions` function endpoint now has an optional `start` argument for accepting query parameter of `start`
- `get_positions_by_wallet_id` db function now accepts `start`, and `limit` parameters to accommodate the change

No breaking changes

Modification to a functionality is done and was to be expected due to the nature of issue.
