### PR TITLE
[Margin app] Add test cases for margin_position endpoints

### DIFF
--- a/margin_app/app/api/margin_position.py
+++ b/margin_app/app/api/margin_position.py
@@ -2,7 +2,6 @@
 This module contains the API routes for margin positions.
 """
 
-from typing import NoReturn
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -19,14 +18,16 @@ router = APIRouter()
 
 
 @router.post("/open", response_model=MarginPositionResponse)
-async def open_margin_position(position_data: MarginPositionCreate):
+async def open_margin_position(
+    position_data: MarginPositionCreate,
+    db: AsyncSession = Depends(margin_position_crud.session),
+):
     """
     Opens a margin position by creating an entry record in the database.
     :param position_data: MarginPositionCreate
     :param db: AsyncSession
     :return: MarginPositionResponse
     """
-    margin_position_crud.db = db
     position = await margin_position_crud.open_margin_position(
         user_id=position_data.user_id,
         borrowed_amount=position_data.borrowed_amount,
@@ -37,7 +38,10 @@ async def open_margin_position(position_data: MarginPositionCreate):
 
 
 @router.post("/close/{position_id}", response_model=CloseMarginPositionResponse)
-async def close_margin_position(position_id: UUID) -> CloseMarginPositionResponse:
+async def close_margin_position(
+    position_id: UUID, 
+    db: AsyncSession = Depends(margin_position_crud.session),
+) -> CloseMarginPositionResponse:
     """
     Close a margin position endpoint.
 

--- a/margin_app/app/tests/api/margin_position.py
+++ b/margin_app/app/tests/api/margin_position.py
@@ -1,0 +1,96 @@
+"""
+Tests for margin position API endpoints.
+"""
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import AsyncClient
+
+from app.api.margin_position import router
+from app.models.margin_position import MarginPositionStatus
+from app.schemas.margin_position import MarginPositionResponse, CloseMarginPositionResponse
+
+
+@pytest.fixture
+def app():
+    """
+    Create a FastAPI app for testing.
+    """
+    app = FastAPI()
+    app.include_router(router, prefix="/margin-positions")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """
+    Create a test client for the app.
+    """
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_open_margin_position():
+    """
+    Mock the open_margin_position method of margin_position_crud.
+    """
+    with patch("app.api.margin_position.margin_position_crud.open_margin_position") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_close_margin_position():
+    """
+    Mock the close_margin_position method of margin_position_crud.
+    """
+    with patch("app.api.margin_position.margin_position_crud.close_margin_position") as mock:
+        yield mock
+
+
+@pytest.fixture
+def valid_position_data():
+    """
+    Create valid position data for testing.
+    """
+    return {
+        "user_id": str(uuid.uuid4()),
+        "borrowed_amount": 1000.00,
+        "multiplier": 5,
+        "transaction_id": "txn_123456789",
+    }
+
+
+@pytest.mark.asyncio
+async def test_open_margin_position_success(client, valid_position_data, mock_open_margin_position):
+    """Test successfully opening a margin position."""
+    data = valid_position_data
+    valid_position_response = MarginPositionResponse(id=str(uuid.uuid4()), status="Open", liquidated_at=None, **data)
+    mock_open_margin_position.return_value = valid_position_response
+    
+    response = client.post("/margin-positions/open", json=data)
+    assert response.status_code == 200
+    assert response.json()["user_id"] == data["user_id"]
+    assert response.json()["borrowed_amount"] == str(data["borrowed_amount"])
+    assert response.json()["multiplier"] == data["multiplier"]
+    assert response.json()["status"] == "Open"
+    mock_open_margin_position.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_close_margin_position_success(client, mock_close_margin_position):
+    """Test successfully closing a margin position."""
+    position_id = uuid.uuid4()
+    mock_close_margin_position.return_value = MarginPositionStatus.CLOSED
+    
+    response = client.post(f"/margin-positions/close/{position_id}")
+    
+    assert response.status_code == 200
+    assert response.json()["position_id"] == str(position_id)
+    assert response.json()["status"] == "Closed"
+    mock_close_margin_position.assert_called_once_with(position_id)
+
+


### PR DESCRIPTION
i have to create unit tests for margin_positions api.
But unfortunately it will take more time, because api was broken a little bit =)



### API fixes:
* [`margin_app/app/api/margin_position.py`](diffhunk://#diff-4d4c76ecf0a57b6f697823b015ce762af25b6df192669e7c3cc54bcb8fd0d605L22-L29): Refactored the `open_margin_position` and `close_margin_position` endpoints to include `AsyncSession` as a dependency. This change ensures that the database session is properly managed during API operations. 

### Testing Enhancements:
* [`margin_app/app/tests/api/margin_position.py`](diffhunk://#diff-0c6c38a98345f08037ddde6e858b46381adb027201d54cffdf7f4c87768d3b61R1-R96): Added new tests for the margin position API endpoints. The tests cover the successful opening and closing of margin positions, utilizing mock objects to simulate database operations.