### PR TITLE
[Margin App] Add logic for Order model

### DIFF
--- a/margin_app/app/alembic/versions/2025-03-07_new_order_model.py
+++ b/margin_app/app/alembic/versions/2025-03-07_new_order_model.py
@@ -1,0 +1,48 @@
+"""new order model
+
+Revision ID: a1b2c3d4e5f6
+Revises: fe041c2f01ee
+Create Date: 2025-03-07 09:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "fe041c2f01ee"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create order table."""
+    op.create_table(
+        "order",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id", UUID(as_uuid=True), sa.ForeignKey("user.id"), nullable=False
+        ),
+        sa.Column("price", sa.Numeric(precision=10, scale=2), nullable=False),
+        sa.Column("token", sa.VARCHAR(), nullable=False),
+        sa.Column("position", UUID(as_uuid=True), nullable=False),
+    )
+
+
+def downgrade():
+    """Drop order table."""
+    op.drop_table("order")

--- a/margin_app/app/api/order.py
+++ b/margin_app/app/api/order.py
@@ -1,0 +1,51 @@
+"""
+API endpoints for order management.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.order import order_crud
+from app.models.order import Order
+from app.schemas.order import OrderCreate, OrderResponse
+
+router = APIRouter()
+
+
+@router.post(
+    "/create_order",
+    response_model=OrderResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new order",
+    description="Creates a new order in the system",
+)
+async def create_order(
+    order_data: OrderCreate,
+    db: AsyncSession = Depends(order_crud.session),
+) -> Order:
+    """
+    Create a new order with the provided order data.
+
+    Args:
+        order_data: The order data to create
+        order_crud: The OrderCRUD instance for database operations
+
+    Returns:
+        The created order
+
+    Raises:
+        HTTPException: If there's an error creating the order
+    """
+    try:
+        order = await order_crud.add_new_order(
+            user_id=order_data.user_id,
+            price=order_data.price,
+            token=order_data.token,
+            position=order_data.position,
+        )
+        return order
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to create order: {str(e)}",
+        )

--- a/margin_app/app/api/order.py
+++ b/margin_app/app/api/order.py
@@ -3,6 +3,7 @@ API endpoints for order management.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.order import order_crud
@@ -44,7 +45,7 @@ async def create_order(
             position=order_data.position,
         )
         return order
-    except Exception as e:
+    except SQLAlchemyError as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to create order: {str(e)}",

--- a/margin_app/app/crud/order.py
+++ b/margin_app/app/crud/order.py
@@ -2,42 +2,41 @@
 This module contains CRUD operations for orders.
 """
 
-import uuid
 import logging
-from app.models.order import Order
+import uuid
+
 from app.crud.base import DBConnector
+from app.models.order import Order
 
 logger = logging.getLogger(__name__)
+
 
 class OrderCRUD(DBConnector):
     """
     CRUD operations for Order model.
-    
+
     Methods:
     - add_new_order: Create and store a new order in the database
     - execute_order: Process and execute an existing order
     """
-    
-    async def add_new_order(self, user_id: uuid.UUID, price: float, token: str, position: uuid.UUID) -> Order:
+
+    async def add_new_order(
+        self, user_id: uuid.UUID, price: float, token: str, position: uuid.UUID
+    ) -> Order:
         """
         Creates a new order in the database.
-        
+
         Args:
             user_id (uuid.UUID): ID of the user placing the order
             price (float): Price of the order
             token (str): Token symbol for the order
             position (uuid.UUID): Position ID related to the order
-            
+
         Returns:
             Order: The newly created order object
         """
-        order = Order(
-            user_id=user_id,
-            price=price,
-            token=token,
-            position=position
-        )
-        
+        order = Order(user_id=user_id, price=price, token=token, position=position)
+
         try:
             order = await self.write_to_db(order)
             logger.info(f"New order created with ID: {order.id}")
@@ -45,14 +44,14 @@ class OrderCRUD(DBConnector):
         except Exception as e:
             logger.error(f"Error creating order: {str(e)}")
             raise
-    
+
     async def execute_order(self, order_id: uuid.UUID) -> bool:
         """
         Processes and executes an order by its ID.
-        
+
         Args:
             order_id (uuid.UUID): ID of the order to execute
-            
+
         Returns:
             bool: True if the order was successfully executed, False otherwise
         """
@@ -61,12 +60,12 @@ class OrderCRUD(DBConnector):
             if not order:
                 logger.warning(f"Order with ID {order_id} not found")
                 return False
-                
+
             # Order execution logic would go here
             # This could include updating the order status, processing the transaction, etc.
             logger.info(f"Order {order_id} executed successfully")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to execute order {order_id}: {str(e)}")
             return False

--- a/margin_app/app/crud/order.py
+++ b/margin_app/app/crud/order.py
@@ -62,10 +62,12 @@ class OrderCRUD(DBConnector):
                 return False
 
             # Order execution logic would go here
-            # This could include updating the order status, processing the transaction, etc.
             logger.info(f"Order {order_id} executed successfully")
             return True
 
         except Exception as e:
             logger.error(f"Failed to execute order {order_id}: {str(e)}")
             return False
+
+
+order_crud = OrderCRUD()

--- a/margin_app/app/crud/order.py
+++ b/margin_app/app/crud/order.py
@@ -4,6 +4,7 @@ This module contains CRUD operations for orders.
 
 import logging
 import uuid
+from decimal import Decimal
 
 from app.crud.base import DBConnector
 from app.models.order import Order
@@ -21,7 +22,7 @@ class OrderCRUD(DBConnector):
     """
 
     async def add_new_order(
-        self, user_id: uuid.UUID, price: float, token: str, position: uuid.UUID
+        self, user_id: uuid.UUID, price: Decimal, token: str, position: uuid.UUID
     ) -> Order:
         """
         Creates a new order in the database.
@@ -36,14 +37,8 @@ class OrderCRUD(DBConnector):
             Order: The newly created order object
         """
         order = Order(user_id=user_id, price=price, token=token, position=position)
-
-        try:
-            order = await self.write_to_db(order)
-            logger.info(f"New order created with ID: {order.id}")
-            return order
-        except Exception as e:
-            logger.error(f"Error creating order: {str(e)}")
-            raise
+        order = await self.write_to_db(order)
+        return order
 
     async def execute_order(self, order_id: uuid.UUID) -> bool:
         """
@@ -55,19 +50,12 @@ class OrderCRUD(DBConnector):
         Returns:
             bool: True if the order was successfully executed, False otherwise
         """
-        try:
-            order = await self.get_object(Order, order_id)
-            if not order:
-                logger.warning(f"Order with ID {order_id} not found")
-                return False
-
-            # Order execution logic would go here
-            logger.info(f"Order {order_id} executed successfully")
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to execute order {order_id}: {str(e)}")
+        order = await self.get_object(Order, order_id)
+        if not order:
             return False
+
+        # Order execution logic would go here
+        return True
 
 
 order_crud = OrderCRUD()

--- a/margin_app/app/crud/order.py
+++ b/margin_app/app/crud/order.py
@@ -1,0 +1,72 @@
+"""
+This module contains CRUD operations for orders.
+"""
+
+import uuid
+import logging
+from app.models.order import Order
+from app.crud.base import DBConnector
+
+logger = logging.getLogger(__name__)
+
+class OrderCRUD(DBConnector):
+    """
+    CRUD operations for Order model.
+    
+    Methods:
+    - add_new_order: Create and store a new order in the database
+    - execute_order: Process and execute an existing order
+    """
+    
+    async def add_new_order(self, user_id: uuid.UUID, price: float, token: str, position: uuid.UUID) -> Order:
+        """
+        Creates a new order in the database.
+        
+        Args:
+            user_id (uuid.UUID): ID of the user placing the order
+            price (float): Price of the order
+            token (str): Token symbol for the order
+            position (uuid.UUID): Position ID related to the order
+            
+        Returns:
+            Order: The newly created order object
+        """
+        order = Order(
+            user_id=user_id,
+            price=price,
+            token=token,
+            position=position
+        )
+        
+        try:
+            order = await self.write_to_db(order)
+            logger.info(f"New order created with ID: {order.id}")
+            return order
+        except Exception as e:
+            logger.error(f"Error creating order: {str(e)}")
+            raise
+    
+    async def execute_order(self, order_id: uuid.UUID) -> bool:
+        """
+        Processes and executes an order by its ID.
+        
+        Args:
+            order_id (uuid.UUID): ID of the order to execute
+            
+        Returns:
+            bool: True if the order was successfully executed, False otherwise
+        """
+        try:
+            order = await self.get_object(Order, order_id)
+            if not order:
+                logger.warning(f"Order with ID {order_id} not found")
+                return False
+                
+            # Order execution logic would go here
+            # This could include updating the order status, processing the transaction, etc.
+            logger.info(f"Order {order_id} executed successfully")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to execute order {order_id}: {str(e)}")
+            return False

--- a/margin_app/app/main.py
+++ b/margin_app/app/main.py
@@ -1,16 +1,18 @@
 """
-Main entry point for the application.
+Main FastAPI application entry point.
 """
 
 import sys
+
 from fastapi import FastAPI, Request
 from loguru import logger
 
+from app.api.deposit import router as deposit_router
 from app.api.liquidation import router as liquidation_router
 from app.api.margin_position import router as margin_position_router
+from app.api.order import router as order_router
 from app.api.pools import router as pool_router
 from app.api.user import router as user_router
-from app.api.deposit import router as deposit_router
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -28,6 +30,7 @@ app.include_router(
 )
 app.include_router(user_router, prefix="/api/user", tags=["User"])
 app.include_router(deposit_router, prefix="/api/deposit", tags=["Deposit"])
+app.include_router(order_router, prefix="/api/order", tags=["Order"])
 
 # Configure Loguru
 logger.remove()  # Remove default logger to configure custom settings
@@ -40,6 +43,7 @@ logger.add(
     diagnose=True,
 )
 
+
 @app.on_event("startup")
 async def startup_event():
     """
@@ -47,6 +51,7 @@ async def startup_event():
     For example, database connection setup or loading configurations.
     """
     logger.info("Application startup: Initializing resources.")
+
 
 @app.on_event("shutdown")
 async def shutdown_event():
@@ -67,7 +72,7 @@ async def log_requests(request: Request, call_next):
     logger.info(f"Response: {response.status_code} {request.url}")
     return response
 
-  
+
 # Additional route
 @app.get("/health")
 async def health_check():

--- a/margin_app/app/models/order.py
+++ b/margin_app/app/models/order.py
@@ -6,7 +6,7 @@ from sqlalchemy import VARCHAR, Numeric, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
-from base import BaseModel
+from app.models.base import BaseModel
 
 
 class Order(BaseModel):

--- a/margin_app/app/models/order.py
+++ b/margin_app/app/models/order.py
@@ -2,7 +2,8 @@
 Order model
 """
 
-from sqlalchemy import VARCHAR, Numeric, ForeignKey
+from decimal import Decimal
+from sqlalchemy import VARCHAR, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -16,8 +17,7 @@ class Order(BaseModel):
     Attributes:
     - user_id (UUID): The unique identifier of the user who placed the order.
                       Acts as both a primary key and a foreign key referencing the "user" table.
-    - price (float): The price of the order,
-    stored with a precision of up to 10 digits and 2 decimal places.
+    - price (Decimal): The price of the order.
     - token (str): The token associated with the order.
     - position (UUID): The identifier of the position related to the order.
 
@@ -27,6 +27,6 @@ class Order(BaseModel):
     __tablename__ = "order"
     user_id: Mapped[UUID] = mapped_column(UUID(as_uuid=True),
                                           ForeignKey("user.id"), primary_key=True)
-    price: Mapped[float] = mapped_column(Numeric(precision=10, scale=2))
+    price: Mapped[Decimal] = mapped_column(nullable=False)
     token: Mapped[str] = mapped_column(VARCHAR)
     position: Mapped[UUID] = mapped_column(UUID(as_uuid=True))

--- a/margin_app/app/schemas/order.py
+++ b/margin_app/app/schemas/order.py
@@ -1,0 +1,31 @@
+"""
+Pydantic schemas for order operations.
+"""
+
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class OrderCreate(BaseModel):
+    """Schema for creating a new order"""
+
+    user_id: uuid.UUID = Field(..., description="ID of the user placing the order")
+    price: float = Field(..., description="Price of the order")
+    token: str = Field(..., description="Token symbol for the order")
+    position: uuid.UUID = Field(..., description="Position ID related to the order")
+
+
+class OrderResponse(BaseModel):
+    """Schema for order response"""
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    price: float
+    token: str
+    position: uuid.UUID
+
+    class Config:
+        """Pydantic model configuration"""
+
+        from_attributes = True

--- a/margin_app/app/schemas/order.py
+++ b/margin_app/app/schemas/order.py
@@ -3,6 +3,7 @@ Pydantic schemas for order operations.
 """
 
 import uuid
+from decimal import Decimal
 
 from pydantic import BaseModel, Field
 
@@ -11,7 +12,7 @@ class OrderCreate(BaseModel):
     """Schema for creating a new order"""
 
     user_id: uuid.UUID = Field(..., description="ID of the user placing the order")
-    price: float = Field(..., description="Price of the order")
+    price: Decimal = Field(..., description="Price of the order")
     token: str = Field(..., description="Token symbol for the order")
     position: uuid.UUID = Field(..., description="Position ID related to the order")
 
@@ -21,7 +22,7 @@ class OrderResponse(BaseModel):
 
     id: uuid.UUID
     user_id: uuid.UUID
-    price: float
+    price: Decimal
     token: str
     position: uuid.UUID
 

--- a/margin_app/app/tests/api/order.py
+++ b/margin_app/app/tests/api/order.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for Order API endpoints using function-based approach without async/await.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+
+from app.api.order import router
+from app.main import app
+from app.models.order import Order
+
+
+@pytest.fixture
+def app():
+    """
+    Create a FastAPI app for testing.
+    """
+    test_app = FastAPI()
+    test_app.include_router(router, prefix="/order")
+    return test_app
+
+
+@pytest.fixture
+def client(app):
+    """
+    Create a test client for the app.
+    """
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_add_new_order():
+    """
+    Mock the add_new_order method of order_crud.
+    """
+    with patch("app.api.order.order_crud.add_new_order") as mock:
+        yield mock
+
+
+def create_mock_order():
+    """Helper function to create a mock Order instance"""
+    order_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    position_id = uuid.uuid4()
+
+    mock_order = MagicMock(spec=Order)
+    mock_order.id = order_id
+    mock_order.user_id = user_id
+    mock_order.price = 100.50
+    mock_order.token = "BTC"
+    mock_order.position = position_id
+
+    return mock_order
+
+
+def test_create_order_success(client, mock_add_new_order):
+    """Test successful order creation"""
+    mock_order = create_mock_order()
+    mock_add_new_order.return_value = mock_order
+
+    response = client.post(
+        "/order/create_order",
+        json={
+            "user_id": str(mock_order.user_id),
+            "price": mock_order.price,
+            "token": mock_order.token,
+            "position": str(mock_order.position),
+        },
+    )
+
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert "id" in data
+    assert data["price"] == mock_order.price
+    assert data["token"] == mock_order.token
+    assert data["user_id"] == str(mock_order.user_id)
+    assert data["position"] == str(mock_order.position)
+
+    mock_add_new_order.assert_called_once_with(
+        user_id=mock_order.user_id,
+        price=mock_order.price,
+        token=mock_order.token,
+        position=mock_order.position,
+    )
+
+
+def test_create_order_invalid_data(client, mock_add_new_order):
+    """Test order creation with invalid data"""
+    response = client.post(
+        "/order/create_order",
+        json={
+            "user_id": "not-a-uuid",
+            "price": 100.50,
+            "token": "BTC",
+            "position": str(uuid.uuid4()),
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    data = response.json()
+    assert "detail" in data
+
+
+def test_create_order_database_error(client, mock_add_new_order):
+    """Test order creation with database error"""
+    mock_add_new_order.side_effect = Exception("Database error")
+    user_id = uuid.uuid4()
+    position_id = uuid.uuid4()
+
+    response = client.post(
+        "/order/create_order",
+        json={
+            "user_id": str(user_id),
+            "price": 100.50,
+            "token": "BTC",
+            "position": str(position_id),
+        },
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    data = response.json()
+    assert "detail" in data
+    assert "Failed to create order" in data["detail"]

--- a/margin_app/app/tests/api/order.py
+++ b/margin_app/app/tests/api/order.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.api.order import router
-from app.main import app
 from app.models.order import Order
 
 
@@ -75,7 +75,7 @@ def test_create_order_success(client, mock_add_new_order):
     assert response.status_code == status.HTTP_201_CREATED
     data = response.json()
     assert "id" in data
-    assert data["price"] == mock_order.price
+    assert data["price"] == str(mock_order.price)
     assert data["token"] == mock_order.token
     assert data["user_id"] == str(mock_order.user_id)
     assert data["position"] == str(mock_order.position)
@@ -107,7 +107,7 @@ def test_create_order_invalid_data(client, mock_add_new_order):
 
 def test_create_order_database_error(client, mock_add_new_order):
     """Test order creation with database error"""
-    mock_add_new_order.side_effect = Exception("Database error")
+    mock_add_new_order.side_effect = SQLAlchemyError("Database error")
     user_id = uuid.uuid4()
     position_id = uuid.uuid4()
 

--- a/margin_app/app/tests/test_order_crud.py
+++ b/margin_app/app/tests/test_order_crud.py
@@ -3,14 +3,14 @@ Unit tests for the OrderCRUD class.
 """
 
 import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.crud.order import OrderCRUD
 from app.models.order import Order
 
-# Test data
 TEST_USER_ID = uuid.uuid4()
 TEST_POSITION_ID = uuid.uuid4()
 TEST_ORDER_ID = uuid.uuid4()
@@ -39,19 +39,18 @@ def mock_order():
 @pytest.mark.asyncio
 async def test_add_new_order_success(order_crud, mock_order):
     """Test successfully adding a new order"""
-    # Arrange
-    with patch.object(order_crud, 'write_to_db', new_callable=AsyncMock) as mock_write_to_db:
+    with patch.object(
+        order_crud, "write_to_db", new_callable=AsyncMock
+    ) as mock_write_to_db:
         mock_write_to_db.return_value = mock_order
-        
-        # Act
+
         result = await order_crud.add_new_order(
             user_id=TEST_USER_ID,
             price=TEST_PRICE,
             token=TEST_TOKEN,
-            position=TEST_POSITION_ID
+            position=TEST_POSITION_ID,
         )
-        
-        # Assert
+
         assert mock_write_to_db.called
         assert result == mock_order
         assert result.user_id == TEST_USER_ID
@@ -63,31 +62,30 @@ async def test_add_new_order_success(order_crud, mock_order):
 @pytest.mark.asyncio
 async def test_add_new_order_exception(order_crud):
     """Test exception handling when adding a new order fails"""
-    # Arrange
-    with patch.object(order_crud, 'write_to_db', new_callable=AsyncMock) as mock_write_to_db:
+    with patch.object(
+        order_crud, "write_to_db", new_callable=AsyncMock
+    ) as mock_write_to_db:
         mock_write_to_db.side_effect = SQLAlchemyError("Database error")
-        
-        # Act & Assert
+
         with pytest.raises(Exception):
             await order_crud.add_new_order(
                 user_id=TEST_USER_ID,
                 price=TEST_PRICE,
                 token=TEST_TOKEN,
-                position=TEST_POSITION_ID
+                position=TEST_POSITION_ID,
             )
 
 
 @pytest.mark.asyncio
 async def test_execute_order_success(order_crud, mock_order):
     """Test successfully executing an order"""
-    # Arrange
-    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+    with patch.object(
+        order_crud, "get_object", new_callable=AsyncMock
+    ) as mock_get_object:
         mock_get_object.return_value = mock_order
-        
-        # Act
+
         result = await order_crud.execute_order(TEST_ORDER_ID)
-        
-        # Assert
+
         mock_get_object.assert_called_once_with(Order, TEST_ORDER_ID)
         assert result is True
 
@@ -95,14 +93,13 @@ async def test_execute_order_success(order_crud, mock_order):
 @pytest.mark.asyncio
 async def test_execute_order_not_found(order_crud):
     """Test executing an order that doesn't exist"""
-    # Arrange
-    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+    with patch.object(
+        order_crud, "get_object", new_callable=AsyncMock
+    ) as mock_get_object:
         mock_get_object.return_value = None
-        
-        # Act
+
         result = await order_crud.execute_order(TEST_ORDER_ID)
-        
-        # Assert
+
         mock_get_object.assert_called_once_with(Order, TEST_ORDER_ID)
         assert result is False
 
@@ -110,14 +107,13 @@ async def test_execute_order_not_found(order_crud):
 @pytest.mark.asyncio
 async def test_execute_order_exception(order_crud):
     """Test exception handling when executing an order fails"""
-    # Arrange
-    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+    with patch.object(
+        order_crud, "get_object", new_callable=AsyncMock
+    ) as mock_get_object:
         mock_get_object.side_effect = Exception("Unexpected error")
-        
-        # Act
+
         result = await order_crud.execute_order(TEST_ORDER_ID)
-        
-        # Assert
+
         mock_get_object.assert_called_once_with(Order, TEST_ORDER_ID)
         assert result is False
 
@@ -125,15 +121,14 @@ async def test_execute_order_exception(order_crud):
 @pytest.mark.asyncio
 async def test_execute_order_integration(order_crud, mock_order):
     """
-    Integration test for execute_order that tests the full flow 
+    Integration test for execute_order that tests the full flow
     with minimal mocking
     """
-    # This test would typically use a test database
-    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+    with patch.object(
+        order_crud, "get_object", new_callable=AsyncMock
+    ) as mock_get_object:
         mock_get_object.return_value = mock_order
-        
-        # Act - execute the order
+
         success = await order_crud.execute_order(TEST_ORDER_ID)
-        
-        # Assert
+
         assert success is True

--- a/margin_app/app/tests/test_order_crud.py
+++ b/margin_app/app/tests/test_order_crud.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for the OrderCRUD class.
+"""
+
+import uuid
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.crud.order import OrderCRUD
+from app.models.order import Order
+
+# Test data
+TEST_USER_ID = uuid.uuid4()
+TEST_POSITION_ID = uuid.uuid4()
+TEST_ORDER_ID = uuid.uuid4()
+TEST_PRICE = 100.50
+TEST_TOKEN = "BTC"
+
+
+@pytest.fixture
+def order_crud():
+    """Fixture to create an OrderCRUD instance for testing"""
+    return OrderCRUD()
+
+
+@pytest.fixture
+def mock_order():
+    """Fixture to create a mock Order object"""
+    order = MagicMock(spec=Order)
+    order.id = TEST_ORDER_ID
+    order.user_id = TEST_USER_ID
+    order.price = TEST_PRICE
+    order.token = TEST_TOKEN
+    order.position = TEST_POSITION_ID
+    return order
+
+
+@pytest.mark.asyncio
+async def test_add_new_order_success(order_crud, mock_order):
+    """Test successfully adding a new order"""
+    # Arrange
+    with patch.object(order_crud, 'write_to_db', new_callable=AsyncMock) as mock_write_to_db:
+        mock_write_to_db.return_value = mock_order
+        
+        # Act
+        result = await order_crud.add_new_order(
+            user_id=TEST_USER_ID,
+            price=TEST_PRICE,
+            token=TEST_TOKEN,
+            position=TEST_POSITION_ID
+        )
+        
+        # Assert
+        assert mock_write_to_db.called
+        assert result == mock_order
+        assert result.user_id == TEST_USER_ID
+        assert result.price == TEST_PRICE
+        assert result.token == TEST_TOKEN
+        assert result.position == TEST_POSITION_ID
+
+
+@pytest.mark.asyncio
+async def test_add_new_order_exception(order_crud):
+    """Test exception handling when adding a new order fails"""
+    # Arrange
+    with patch.object(order_crud, 'write_to_db', new_callable=AsyncMock) as mock_write_to_db:
+        mock_write_to_db.side_effect = SQLAlchemyError("Database error")
+        
+        # Act & Assert
+        with pytest.raises(Exception):
+            await order_crud.add_new_order(
+                user_id=TEST_USER_ID,
+                price=TEST_PRICE,
+                token=TEST_TOKEN,
+                position=TEST_POSITION_ID
+            )
+
+
+@pytest.mark.asyncio
+async def test_execute_order_success(order_crud, mock_order):
+    """Test successfully executing an order"""
+    # Arrange
+    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+        mock_get_object.return_value = mock_order
+        
+        # Act
+        result = await order_crud.execute_order(TEST_ORDER_ID)
+        
+        # Assert
+        mock_get_object.assert_called_once_with(Order, TEST_ORDER_ID)
+        assert result is True
+
+
+@pytest.mark.asyncio
+async def test_execute_order_not_found(order_crud):
+    """Test executing an order that doesn't exist"""
+    # Arrange
+    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+        mock_get_object.return_value = None
+        
+        # Act
+        result = await order_crud.execute_order(TEST_ORDER_ID)
+        
+        # Assert
+        mock_get_object.assert_called_once_with(Order, TEST_ORDER_ID)
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_execute_order_exception(order_crud):
+    """Test exception handling when executing an order fails"""
+    # Arrange
+    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+        mock_get_object.side_effect = Exception("Unexpected error")
+        
+        # Act
+        result = await order_crud.execute_order(TEST_ORDER_ID)
+        
+        # Assert
+        mock_get_object.assert_called_once_with(Order, TEST_ORDER_ID)
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_execute_order_integration(order_crud, mock_order):
+    """
+    Integration test for execute_order that tests the full flow 
+    with minimal mocking
+    """
+    # This test would typically use a test database
+    with patch.object(order_crud, 'get_object', new_callable=AsyncMock) as mock_get_object:
+        mock_get_object.return_value = mock_order
+        
+        # Act - execute the order
+        success = await order_crud.execute_order(TEST_ORDER_ID)
+        
+        # Assert
+        assert success is True

--- a/margin_app/app/tests/test_order_crud.py
+++ b/margin_app/app/tests/test_order_crud.py
@@ -3,6 +3,7 @@ Unit tests for the OrderCRUD class.
 """
 
 import uuid
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,7 +15,7 @@ from app.models.order import Order
 TEST_USER_ID = uuid.uuid4()
 TEST_POSITION_ID = uuid.uuid4()
 TEST_ORDER_ID = uuid.uuid4()
-TEST_PRICE = 100.50
+TEST_PRICE = Decimal("100.50")
 TEST_TOKEN = "BTC"
 
 
@@ -110,12 +111,12 @@ async def test_execute_order_exception(order_crud):
     with patch.object(
         order_crud, "get_object", new_callable=AsyncMock
     ) as mock_get_object:
-        mock_get_object.side_effect = Exception("Unexpected error")
+        mock_get_object.side_effect = SQLAlchemyError("Database error")
 
-        result = await order_crud.execute_order(TEST_ORDER_ID)
+        with pytest.raises(Exception):
+            _ = await order_crud.execute_order(TEST_ORDER_ID)
 
         mock_get_object.assert_called_once_with(Order, TEST_ORDER_ID)
-        assert result is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #702 
 a new order management system to the `margin_app` application. 

* Created a new migration for order model . (`margin_app/app/alembic/versions/2025-03-07_new_order_model.py`)

* Added CRUD operations for the `Order` model in `margin_app/app/crud/order.py`.
* Implemented API endpoints for creating orders in `margin_app/app/api/order.py`.
* Included the new `order` API router in the main application entry point in `margin_app/app/main.py`.

** Defined Pydantic schemas for order creation and response in `margin_app/app/schemas/order.py`.
** Added unit tests for the `Order` API endpoints in `margin_app/app/tests/api/order.py`.
** Added unit tests for the `OrderCRUD` class in `margin_app/app/tests/test_order_crud.py`.