### PR TITLE
fix classBuilder

### DIFF
--- a/margin/margin_frontend/src/utils/utils.ts
+++ b/margin/margin_frontend/src/utils/utils.ts
@@ -1,3 +1,3 @@
 export function classBuilder(...classes: (string | boolean)[]) {
-  return classes.filter(String).join(" ");
+  return classes.filter(s => typeof s === 'string' && s).join(' ');
 }


### PR DESCRIPTION
The previous version determined booleans as strings and returned classes like: 'false'

Review request:
@djeck1432 