### PR TITLE
Feat/fix failing tests

### DIFF
--- a/margin/margin_app/app/api/admin.py
+++ b/margin/margin_app/app/api/admin.py
@@ -143,7 +143,7 @@ async def change_password(
     Returns:
         JSONResponse: A response indicating that the reset password email was successfully sent.
     """
-    admin = await admin_crud.get_object_by_field(field="email", value=admin_email)
+    admin = await admin_crud.get_by_email(admin_email)
 
     if not admin:
         raise HTTPException(

--- a/margin/margin_app/app/api/auth.py
+++ b/margin/margin_app/app/api/auth.py
@@ -100,7 +100,7 @@ async def change_password(
     Returns:
         JSONResponse: A response indicating that the reset password email was successfully sent.
     """
-    admin = await admin_crud.get_object_by_field(field="email", value=admin_email)
+    admin = await admin_crud.get_by_email(admin_email)
 
     if not admin:
         raise HTTPException(

--- a/margin/margin_app/app/api/deposit.py
+++ b/margin/margin_app/app/api/deposit.py
@@ -49,17 +49,22 @@ async def create_deposit(deposit_in: DepositCreate) -> DepositResponse:
 async def update_deposit(
     deposit_id: UUID,
     deposit_update: DepositUpdate,
-):
+) -> Deposit:
     """
     Update a deposit by ID.
-    :param deposit_id: str
+    :param deposit_id: UUID
     :param deposit_update: DepositUpdate data
 
     :return: Deposit
     """
-    return await deposit_crud.update_deposit(
+    deposit = await deposit_crud.update_deposit(
         deposit_id, deposit_update.model_dump(exclude_none=True)
     )
+    if deposit is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, f"Deposit with ID {deposit_id} not found"
+        )
+    return deposit
 
 
 @router.get(

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -52,7 +52,7 @@ def mock_get_all_admin():
 
 @pytest.mark.asyncio
 @patch("app.api.common.GetAllMediator.__call__", new_callable=AsyncMock)
-async def test_get_all_admins(mock_mediator_call, client):
+async def test_get_all_admins(mock_mediator_call, mock_get_admin_by_email, client):
     """
     Test successfully return all admins using the GetAllMediator.
     """

--- a/margin/margin_app/app/tests/conftest.py
+++ b/margin/margin_app/app/tests/conftest.py
@@ -3,7 +3,9 @@
 from fastapi.testclient import TestClient
 import pytest_asyncio
 import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
 from app.crud.base import DBConnector
+from app.core.config import settings
 from app.models.base import BaseModel
 from app.main import app
 import os
@@ -23,17 +25,17 @@ def pytest_configure():
     set_test_env_vars()
 
 
-@pytest_asyncio.fixture
-async def db_connector():
-    """Fixture to create a database connection for testing."""
-    db = DBConnector()
-    async with db.engine.begin() as conn:
-        await conn.run_sync(BaseModel.metadata.create_all)
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def setup_db():
+    """Fixture to create and teardown database migrations"""
+    engine = create_async_engine(settings.db_url)
+    async with engine.begin() as conn:
+        res = await conn.run_sync(BaseModel.metadata.create_all)
     try:
-        yield db
+        yield
     finally:
-        async with db.engine.begin() as conn:
-            await conn.run_sync(BaseModel.metadata.drop_all)
+        async with engine.begin() as conn:
+            res = await conn.run_sync(BaseModel.metadata.drop_all)
 
 
 @pytest.fixture(scope="module")

--- a/margin/margin_app/app/tests/services/test_auth_services.py
+++ b/margin/margin_app/app/tests/services/test_auth_services.py
@@ -58,13 +58,13 @@ async def test_get_current_user_success():
     token = create_access_token(email)
 
     with patch.object(
-        admin_crud, "get_object_by_field", new_callable=AsyncMock
-    ) as get_object_by_field:
-        get_object_by_field.return_value = return_value
+        admin_crud, "get_by_email", new_callable=AsyncMock
+    ) as get_by_email:
+        get_by_email.return_value = return_value
 
         user = await get_current_user(token)
         assert user == return_value
-        get_object_by_field.assert_awaited_once_with(field="email", value=email)
+        get_by_email.assert_awaited_once_with(email)
 
 
 @pytest.mark.asyncio
@@ -103,8 +103,8 @@ async def test_get_current_user_fails_if_usr_not_found():
     token = jwt.encode(to_encode, settings.secret_key, algorithm=ALGORITHM)
 
     with patch.object(
-        admin_crud, "get_object_by_field", new_callable=AsyncMock
-    ) as get_object_by_field:
-        get_object_by_field.return_value = None
+        admin_crud, "get_by_email", new_callable=AsyncMock
+    ) as get_by_email:
+        get_by_email.return_value = None
         with pytest.raises(Exception, match="User not found"):
             await get_current_user(token)

--- a/margin/margin_app/app/tests/test_auth_admin_user_middleware.py
+++ b/margin/margin_app/app/tests/test_auth_admin_user_middleware.py
@@ -9,8 +9,8 @@ from app.services.auth.base import create_access_token
 from app.models.admin import Admin
 from app.crud.admin import admin_crud
 from app.tests.api.test_admin_api import (
-    mock_get_admin_by_email,
     mock_get_all_admin,
+    mock_get_admin_by_email,
     test_admin_object,
 )
 

--- a/margin/margin_app/app/tests/test_db_connector.py
+++ b/margin/margin_app/app/tests/test_db_connector.py
@@ -132,9 +132,11 @@ async def test_delete_nonexistent_object(db_connector):
 
 async def test_write_invalid_object(db_connector):
     """Test attempting to write an invalid object, expecting an Exception."""
-    db_connector.write_to_db = AsyncMock(
-        side_effect=lambda obj: Exception("Cannot write None") if obj is None else obj
-    )
+
+    def side_effect(obj):
+        raise Exception("Cannot write None") if obj is None else obj
+
+    db_connector.write_to_db = AsyncMock(side_effect=side_effect)
 
     with pytest.raises(Exception):
         await db_connector.write_to_db(None)


### PR DESCRIPTION
Addresses issue #855
What was done:

1. Changed all admin_crud.get_object_by_field to get_by_email invocations, which was on of the failure reasons (mixing of two methods and only one of them was mocked)
2. Return HTTP 404 in create_deposit handler if deposit is None
3. Changed test 'test_update_invalid_deposits' which did not make sense to 'test_deposit_update_with_invalid_id'
4. New test: 'test_update_deposit_not_found' which tests new logic described in clause 2
5. autouse of setup_db fixture to properly upgrade and downgrade db migrations