### PR TITLE
feat(admin-dashboard): add admin dashboard stats cards with mock data

### DIFF
--- a/margin/margin_frontend/src/ui/admin/dashboard/AccountValuesCard.tsx
+++ b/margin/margin_frontend/src/ui/admin/dashboard/AccountValuesCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Card from '../../components/Card';
+import { DollarSign, Wallet } from 'lucide-react';
+
+const mockData = {
+  netValue: 45512.72,
+  coinsValue: 34551.4,
+  cashBalance: 10961.32,
+};
+
+const AccountValuesCard: React.FC = () => (
+  <Card className="p-8 max-w-md w-full bg-white text-gray-900 border border-gray-200 shadow-xl">
+    <div className="mb-6">
+      <div className="text-2xl font-semibold mb-2 text-gray-800">Account Values</div>
+      <div className="text-gray-500 text-lg mb-1">Net Value</div>
+      <div className="text-4xl font-bold text-gray-900 mb-2">{mockData.netValue.toLocaleString('en-US', { minimumFractionDigits: 2 })} <span className="text-base font-medium text-gray-500">USD</span></div>
+    </div>
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <span className="bg-blue-100 p-2 rounded-lg"><DollarSign className="text-blue-500 w-6 h-6" /></span>
+        <span className="text-gray-500 text-base font-medium">Coins value</span>
+        <span className="ml-auto text-lg font-semibold text-gray-900">{mockData.coinsValue.toLocaleString('en-US', { minimumFractionDigits: 1 })} <span className="text-xs font-medium text-gray-500">USD</span></span>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="bg-green-100 p-2 rounded-lg"><Wallet className="text-green-500 w-6 h-6" /></span>
+        <span className="text-gray-500 text-base font-medium">Cash Balance</span>
+        <span className="ml-auto text-lg font-semibold text-gray-900">{mockData.cashBalance.toLocaleString('en-US', { minimumFractionDigits: 2 })} <span className="text-xs font-medium text-gray-500">USD</span></span>
+      </div>
+    </div>
+  </Card>
+);
+
+export default AccountValuesCard; 

--- a/margin/margin_frontend/src/ui/admin/dashboard/DashboardStats.tsx
+++ b/margin/margin_frontend/src/ui/admin/dashboard/DashboardStats.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Card from '../../components/Card';
+
+const stats = [
+  { label: 'Users', value: 1200 },
+  { label: 'Opened Positions', value: 340 },
+  { label: 'Liquidated Positions', value: 45 },
+  { label: 'Opened Orders', value: 210 },
+];
+
+const DashboardStats: React.FC = () => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+    {stats.map((stat) => (
+      <Card key={stat.label} className="p-6 flex flex-col items-center text-center">
+        <div className="text-3xl font-bold text-primary mb-2">{stat.value}</div>
+        <div className="text-lg text-gray-400 font-medium">{stat.label}</div>
+      </Card>
+    ))}
+  </div>
+);
+
+export default DashboardStats; 

--- a/margin/margin_frontend/src/ui/admin/dashboard/dashboardMain.tsx
+++ b/margin/margin_frontend/src/ui/admin/dashboard/dashboardMain.tsx
@@ -1,6 +1,7 @@
 import Assets from './assets';
 import AdminLayout from '../AdminLayout';
 import DashboardStats from './DashboardStats';
+import AccountValuesCard from './AccountValuesCard';
 
 const AdminDashboard: React.FC = () => {
   const mockAssetsData = {
@@ -11,7 +12,8 @@ const AdminDashboard: React.FC = () => {
   };
   return (
     <AdminLayout>
-      <div className='text-white'>
+      <div className='text-white flex flex-col items-center gap-8'>
+        <AccountValuesCard />
         <DashboardStats />
         <Assets className='w-full max-w-[900px]' data={mockAssetsData} />
       </div>

--- a/margin/margin_frontend/src/ui/admin/dashboard/dashboardMain.tsx
+++ b/margin/margin_frontend/src/ui/admin/dashboard/dashboardMain.tsx
@@ -1,5 +1,6 @@
 import Assets from './assets';
 import AdminLayout from '../AdminLayout';
+import DashboardStats from './DashboardStats';
 
 const AdminDashboard: React.FC = () => {
   const mockAssetsData = {
@@ -11,6 +12,7 @@ const AdminDashboard: React.FC = () => {
   return (
     <AdminLayout>
       <div className='text-white'>
+        <DashboardStats />
         <Assets className='w-full max-w-[900px]' data={mockAssetsData} />
       </div>
     </AdminLayout>


### PR DESCRIPTION
# Admin Dashboard Page

Closes #868 

## Description

This PR implements the **admin dashboard** page in the frontend, following the issue guidelines:

- **Route:** `/admin/dashboard`
- **Mock data** for:
  - Users
  - Opened positions
  - Liquidated positions
  - Opened orders
- **Visual design** based on the provided example image.
- **Reusable components** and clean structure, all within `margin_frontend` (not in `admin_template`).

## Main Changes

- **New visual component:** `AccountValuesCard` replicates the account values card design (Net Value, Coins value, Cash Balance) with icons and professional formatting.
- **Dashboard integration:** Everything is integrated into the `/admin/dashboard` page using the existing admin layout.
- **Mocked data:** No backend connection yet; all data is static for now.

## Demo

You can view the page at:  
`http://localhost:5173/admin/dashboard`

<img width="1401" alt="Screenshot 2025-05-30 at 6 19 47 PM" src="https://github.com/user-attachments/assets/fd91374a-6ef3-4317-a69b-687178c98e4d" />

## Checklist

- [x] Followed the issue guidelines
- [x] Used mock data (no backend endpoints yet)
- [x] All code is inside `margin_frontend`
- [x] UI matches the provided design example

---

Let me know if you need any changes or further adjustments!