### PR TITLE
feat: Add signup confirmation endpoint and decode signup token functionality

### DIFF
--- a/margin/margin_app/app/api/auth.py
+++ b/margin/margin_app/app/api/auth.py
@@ -211,7 +211,7 @@ async def signup_confirmation(
             httponly=True,
             secure=True,
             path="/",
-            max_age=settings.refresh_token_expire_days * 24 * 60 * 60,
+            max_age=settings.refresh_token_expire_seconds,
         )
 
         return {"access_token": access_token, "token_type": "bearer"}

--- a/margin/margin_app/app/api/auth.py
+++ b/margin/margin_app/app/api/auth.py
@@ -4,15 +4,21 @@ API endpoints for auth logic.
 
 from datetime import timedelta
 
-from fastapi import APIRouter, HTTPException, status, Request
+from fastapi import APIRouter, HTTPException, status, Request, Response
 from fastapi.responses import RedirectResponse, JSONResponse
 from loguru import logger
 from pydantic import EmailStr
 
 from app.core.config import settings
-from app.services.auth.base import google_auth, create_access_token, get_current_user
+from app.services.auth.base import (
+    google_auth,
+    create_access_token,
+    get_current_user,
+    decode_signup_token,
+)
 from app.crud.admin import admin_crud
 from app.schemas.admin import AdminResetPassword
+from app.schemas.auth import SignupConfirmation
 from app.services.auth.security import (
     get_password_hash,
     verify_password,
@@ -151,3 +157,73 @@ async def reset_password(data: AdminResetPassword, token: str):
     admin.password = get_password_hash(data.new_password)
     await admin_crud.write_to_db(admin)
     return JSONResponse(content={"message": "Password was changed"})
+
+
+@router.post("/signup-confirmation", status_code=status.HTTP_200_OK)
+async def signup_confirmation(
+    confirmation: SignupConfirmation,
+    response: Response,
+):
+    """
+    Handle user registration confirmation with JWT token.
+
+    Parameters:
+    - confirmation: SignupConfirmation - The confirmation request containing token, password, and name
+    - response: Response - The HTTP response object to set cookies
+
+    Returns:
+    - dict: The access token and token type
+
+    Raises:
+    - HTTPException: If token is invalid, expired, or user already exists
+    """
+    try:
+        email = decode_signup_token(confirmation.token)
+
+        existing_user = await admin_crud.get_by_email(email)
+        if existing_user:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="User already exists",
+            )
+
+        # Create new user
+        hashed_password = get_password_hash(confirmation.password)
+        user = await admin_crud.create_admin(
+            email=email,
+            name=confirmation.name,
+            password=hashed_password,
+        )
+
+        access_token = create_access_token(
+            email,
+            expires_delta=timedelta(minutes=settings.access_token_expire_minutes),
+        )
+
+        refresh_token = create_access_token(
+            email,
+            expires_delta=timedelta(days=settings.refresh_token_expire_days),
+        )
+
+        response.set_cookie(
+            key="refresh_token",
+            value=refresh_token,
+            httponly=True,
+            secure=True,
+            path="/",
+            max_age=settings.refresh_token_expire_days * 24 * 60 * 60,
+        )
+
+        return {"access_token": access_token, "token_type": "bearer"}
+
+    except Exception as e:
+        logger.error(f"Failed to confirm signup: {str(e)}")
+        if str(e) in ["Invalid token", "Token expired"]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to confirm signup",
+        )

--- a/margin/margin_app/app/api/auth.py
+++ b/margin/margin_app/app/api/auth.py
@@ -168,8 +168,10 @@ async def signup_confirmation(
     Handle user registration confirmation with JWT token.
 
     Parameters:
-    - confirmation: SignupConfirmation - The confirmation request containing token, password, and name
-    - response: Response - The HTTP response object to set cookies
+    - confirmation: SignupConfirmation
+        The confirmation request containing token, password, and name
+    - response: Response
+        The HTTP response object to set cookies
 
     Returns:
     - dict: The access token and token type

--- a/margin/margin_app/app/core/config.py
+++ b/margin/margin_app/app/core/config.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
     reset_password_expire_minutes: int = 15
+    refresh_token_expire_days: int = 7
     host: str = "localhost"
     forget_password_url: str = "/auth/reset_password"
 
@@ -54,6 +55,14 @@ class Settings(BaseSettings):
             database=self.db_name,
             port=self.db_port,
         )
+
+    @computed_field
+    @property
+    def refresh_token_expire_seconds(self) -> int:
+        """
+        Computed property to get refresh token expiration time in seconds
+        """
+        return self.refresh_token_expire_days * 24 * 60 * 60
 
 
 settings = Settings()

--- a/margin/margin_app/app/schemas/auth.py
+++ b/margin/margin_app/app/schemas/auth.py
@@ -12,3 +12,13 @@ class Token(BaseModel):
 
     access_token: str
     token_type: str
+
+
+class SignupConfirmation(BaseModel):
+    """
+    Signup confirmation request model
+    """
+    
+    token: str
+    password: str
+    name: str

--- a/margin/margin_app/app/schemas/auth.py
+++ b/margin/margin_app/app/schemas/auth.py
@@ -3,6 +3,7 @@ This module contains Pydantic schemas for auth.
 """
 
 from pydantic import BaseModel
+from .base import BaseSchema
 
 
 class Token(BaseModel):
@@ -14,7 +15,7 @@ class Token(BaseModel):
     token_type: str
 
 
-class SignupConfirmation(BaseModel):
+class SignupConfirmation(BaseSchema):
     """
     Signup confirmation request model
     """

--- a/margin/margin_app/app/services/auth/base.py
+++ b/margin/margin_app/app/services/auth/base.py
@@ -25,6 +25,30 @@ def get_expire_time(minutes: int) -> datetime:
     return datetime.utcnow() + timedelta(minutes=minutes)
 
 
+def decode_signup_token(token: str) -> str:
+    """
+    Decode the signup JWT token and extract the email address.
+
+    Parameters:
+    - token (str): The JWT token containing the email address.
+
+    Returns:
+    - str: The email address extracted from the token.
+
+    Raises:
+    - Exception("Invalid token"): if token is invalid or missing email
+    - Exception("Token expired"): if token has expired
+    """
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        email = payload.get("sub")
+        if email is None:
+            raise Exception("Invalid token")
+        return email
+    except InvalidTokenError as e:
+        raise Exception("Token expired") from e
+
+
 def create_access_token(email: str, expires_delta: timedelta | None = None):
     """
     Generates auth jwt token for a given wallet ID


### PR DESCRIPTION
- Implemented a new endpoint for user signup confirmation that handles JWT token validation and user creation.
- Added a `decode_signup_token` function to extract email from the JWT token, with error handling for invalid and expired tokens.
- Introduced a `SignupConfirmation` schema for request validation.
- Updated tests to cover the new functionality for decoding signup tokens.

closes- #875 