### PR TITLE
created a feature that add name and also wrote tests

### DIFF
--- a/margin/margin_app/app/api/admin.py
+++ b/margin/margin_app/app/api/admin.py
@@ -17,6 +17,7 @@ from app.schemas.admin import (
     AdminResponse,
     AdminResetPassword,
     AdminGetAllResponse,
+    AdminUpdateRequest
 )
 from app.services.auth.base import get_admin_user_from_state
 from app.services.auth.security import get_password_hash, verify_password
@@ -194,3 +195,44 @@ async def reset_password(data: AdminResetPassword, token: str):
     admin.password = get_password_hash(data.new_password)
     await admin_crud.write_to_db(admin)
     return JSONResponse(content={"message": "Password was changed"})
+
+
+
+@router.post(
+    "/{admin_id}",
+    response_model=AdminResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update admin",
+    description="Update the name of an admin by ID",
+)
+async def update_admin_name(
+    admin_id: UUID,
+    data: AdminUpdateRequest,
+) -> AdminResponse:
+    """
+    Update an admin's name.
+
+    Parameters:
+    - admin_id: UUID of the admin to update
+    - data: AdminUpdateRequest containing updated fields
+
+    Returns:
+    - AdminResponse: Updated admin data
+
+    Raises:
+    - HTTPException: If admin is not found
+    """
+    admin = await admin_crud.get_object(Admin, admin_id)
+
+    if not admin:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Admin not found.",
+        )
+
+    if data.name:
+        admin.name = data.name
+
+    updated_admin = await admin_crud.write_to_db(admin)
+
+    return AdminResponse(id=updated_admin.id, name=updated_admin.name, email=updated_admin.email)

--- a/margin/margin_app/app/schemas/admin.py
+++ b/margin/margin_app/app/schemas/admin.py
@@ -48,3 +48,10 @@ class AdminGetAllResponse(GetAll[AdminResponse]):
     """
     Admin get all response model
     """
+
+
+class AdminUpdateRequest(BaseModel):
+    """
+    Admin update request model (for updating admin fields)
+    """
+    name: Optional[str] = None


### PR DESCRIPTION
This PR introduces a new endpoint that allows updating the name field of an admin using their admin_id. A Pydantic schema has been created to support this functionality, with future extensibility in mind.

**🎯 Key Changes**
✅ Added a new POST /api/admin/{admin_id} endpoint to update the admin's name

✅ Created a dedicated Pydantic schema for the update request

✅ Wrote unit tests to verify successful updates and error handling

**🔗 Related Issue**
Closes 872


