### PR TITLE
Feat add admin

### DIFF
--- a/margin/margin_app/app/api/admin.py
+++ b/margin/margin_app/app/api/admin.py
@@ -221,7 +221,7 @@ async def update_admin_name(
     Raises:
     - HTTPException: If admin is not found
     """
-    admin = await admin_crud.get_object(Admin, admin_id)
+    admin = await admin_crud.get_object(admin_id)
 
     if not admin:
         raise HTTPException(

--- a/margin/margin_app/app/api/admin.py
+++ b/margin/margin_app/app/api/admin.py
@@ -197,7 +197,6 @@ async def reset_password(data: AdminResetPassword, token: str):
     return JSONResponse(content={"message": "Password was changed"})
 
 
-
 @router.post(
     "/{admin_id}",
     response_model=AdminResponse,

--- a/margin/margin_app/app/api/admin.py
+++ b/margin/margin_app/app/api/admin.py
@@ -17,6 +17,7 @@ from app.schemas.admin import (
     AdminResponse,
     AdminResetPassword,
     AdminGetAllResponse,
+    AdminUpdateRequest
 )
 from app.services.auth.base import get_admin_user_from_state
 from app.services.auth.security import get_password_hash, verify_password
@@ -194,3 +195,44 @@ async def reset_password(data: AdminResetPassword, token: str):
     admin.password = get_password_hash(data.new_password)
     await admin_crud.write_to_db(admin)
     return JSONResponse(content={"message": "Password was changed"})
+
+
+
+@router.post(
+    "/{admin_id}",
+    response_model=AdminResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update admin",
+    description="Update the name of an admin by ID",
+)
+async def update_admin_name(
+    admin_id: UUID,
+    data: AdminUpdateRequest,
+) -> AdminResponse:
+    """
+    Update an admin's name.
+
+    Parameters:
+    - admin_id: UUID of the admin to update
+    - data: AdminUpdateRequest containing updated fields
+
+    Returns:
+    - AdminResponse: Updated admin data
+
+    Raises:
+    - HTTPException: If admin is not found
+    """
+    admin = await admin_crud.get_object(Admin, admin_id)
+
+    if not admin:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Admin not found.",
+        )
+
+    if data.name:
+        admin.name = data.name
+
+    updated_admin = await admin_crud.write_to_db(admin)
+
+    return AdminResponse(id=updated_admin.id, name=updated_admin.name, email=updated_admin.email)

--- a/margin/margin_app/app/schemas/admin.py
+++ b/margin/margin_app/app/schemas/admin.py
@@ -48,3 +48,10 @@ class AdminGetAllResponse(GetAll[AdminResponse]):
     """
     Admin get all response model
     """
+
+
+class AdminUpdateRequest(BaseModel):
+    """
+    Admin update request model (for updating admin fields)
+    """
+    name: Optional[str] = None

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -77,15 +77,10 @@ async def test_get_all_admins(mock_mediator_call, mock_get_admin_by_email, clien
 
     mock_mediator_call.assert_called_once()
 
-
 @pytest.mark.asyncio
-@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
-async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_by_email, client):
+async def test_update_admin_success(mock_get_object, client):
     """Test successful admin name update."""
-
-    mock_get_by_email.return_value = test_admin_object
     
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
@@ -93,13 +88,6 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_
         'email': test_admin_object['email']
     })()
     mock_get_object.return_value = mock_admin
-    
-    updated_admin = type('MockAdmin', (), {
-        'id': test_admin_object['id'],
-        'name': 'Updated Name',
-        'email': test_admin_object['email']
-    })()
-    mock_write_to_db.return_value = updated_admin
 
     token = create_access_token(test_admin_object["email"])
     response = client.post(
@@ -116,12 +104,10 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_
 
 
 @pytest.mark.asyncio
-@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client):
+async def test_update_admin_not_found(mock_get_object, client):
     """Test update admin when admin not found."""
 
-    mock_get_by_email.return_value = test_admin_object
     mock_get_object.return_value = None
 
     token = create_access_token(test_admin_object["email"])
@@ -136,13 +122,9 @@ async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client
 
 
 @pytest.mark.asyncio
-@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
-async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_email, client):
+async def test_update_admin_empty_name(mock_get_object, client):
     """Test update admin with empty name."""
- 
-    mock_get_email.return_value = test_admin_object
     
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
@@ -150,7 +132,6 @@ async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_g
         'email': test_admin_object['email']
     })()
     mock_get_object.return_value = mock_admin
-    mock_write_to_db.return_value = mock_admin
 
     token = create_access_token(test_admin_object["email"])
     response = client.post(

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -79,9 +79,7 @@ async def test_get_all_admins(mock_mediator_call, mock_get_admin_by_email, clien
 
 
 @pytest.mark.asyncio
-@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
 async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_by_email, client):
     """Test successful admin name update."""
     # Mock auth user lookup
@@ -118,7 +116,6 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_
 
 
 @pytest.mark.asyncio
-@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client):
     """Test update admin when admin not found."""
@@ -138,15 +135,12 @@ async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client
 
 
 @pytest.mark.asyncio
-@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
 async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_email, client):
     """Test update admin with empty name."""
-    # Mock auth user lookup
+
     mock_get_email.return_value = test_admin_object
     
-    # Mock existing admin
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
         'name': test_admin_object['name'],
@@ -162,5 +156,5 @@ async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_g
         headers={"Authorization": f"Bearer {token}"}
     )
 
-    # Should still work but name won't be updated since it's empty
+ 
     assert response.status_code == 200

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -84,10 +84,9 @@ async def test_get_all_admins(mock_mediator_call, mock_get_admin_by_email, clien
 @patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
 async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_by_email, client):
     """Test successful admin name update."""
-    # Mock auth user lookup
+
     mock_get_by_email.return_value = test_admin_object
     
-    # Mock existing admin
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
         'name': test_admin_object['name'],
@@ -95,7 +94,6 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_
     })()
     mock_get_object.return_value = mock_admin
     
-    # Mock updated admin
     updated_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
         'name': 'Updated Name',
@@ -122,7 +120,7 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client):
     """Test update admin when admin not found."""
-    # Mock auth user lookup
+
     mock_get_by_email.return_value = test_admin_object
     mock_get_object.return_value = None
 
@@ -141,12 +139,11 @@ async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client
 @patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
-async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_by_email, client):
+async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_email, client):
     """Test update admin with empty name."""
-    # Mock auth user lookup
-    mock_get_by_email.return_value = test_admin_object
+ 
+    mock_get_email.return_value = test_admin_object
     
-    # Mock existing admin
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
         'name': test_admin_object['name'],
@@ -162,5 +159,4 @@ async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_g
         headers={"Authorization": f"Bearer {token}"}
     )
 
-    # Should still work but name won't be updated since it's empty
     assert response.status_code == 200

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -77,13 +77,16 @@ async def test_get_all_admins(mock_mediator_call, mock_get_admin_by_email, clien
 
     mock_mediator_call.assert_called_once()
 
-# Add these tests to your test_admin.py file
 
 @pytest.mark.asyncio
+@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
-async def test_update_admin_success(mock_write_to_db, mock_get_object, client):
+async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_by_email, client):
     """Test successful admin name update."""
+    # Mock auth user lookup
+    mock_get_by_email.return_value = test_admin_object
+    
     # Mock existing admin
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
@@ -115,9 +118,12 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, client):
 
 
 @pytest.mark.asyncio
+@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-async def test_update_admin_not_found(mock_get_object, client):
+async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client):
     """Test update admin when admin not found."""
+    # Mock auth user lookup
+    mock_get_by_email.return_value = test_admin_object
     mock_get_object.return_value = None
 
     token = create_access_token(test_admin_object["email"])
@@ -132,10 +138,14 @@ async def test_update_admin_not_found(mock_get_object, client):
 
 
 @pytest.mark.asyncio
+@patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
-async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, client):
+async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_by_email, client):
     """Test update admin with empty name."""
+    # Mock auth user lookup
+    mock_get_by_email.return_value = test_admin_object
+    
     # Mock existing admin
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -141,10 +141,10 @@ async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client
 @patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
-async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_by_email, client):
+async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_email, client):
     """Test update admin with empty name."""
     # Mock auth user lookup
-    mock_get_by_email.return_value = test_admin_object
+    mock_get_email.return_value = test_admin_object
     
     # Mock existing admin
     mock_admin = type('MockAdmin', (), {

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -78,23 +78,19 @@ async def test_get_all_admins(mock_mediator_call, mock_get_admin_by_email, clien
     mock_mediator_call.assert_called_once()
 
 
-
-@pytest.mark.asyncio
 @patch("app.crud.base.DBConnector.get_object", new_callable=AsyncMock)
 @patch("app.crud.base.DBConnector.write_to_db", new_callable=AsyncMock)
 def test_update_admin_name(
     mock_write_to_db,
     mock_get_object,
-    mock_get_admin_by_email,
     client,
 ):
     """
     Test updating an admin's name.
     """
-
-    # Mock existing admin
-    admin_id = test_admin_object["id"]
+    admin_id = str(test_admin_object["id"])  
     updated_name = "New Admin Name"
+
     mock_get_object.return_value = test_admin_object
     mock_write_to_db.return_value = {
         **test_admin_object,
@@ -104,7 +100,7 @@ def test_update_admin_name(
     token = create_access_token(test_admin_object["email"])
 
     response = client.post(
-        ADMIN_URL + f"{admin_id}",
+        f"/api/admin/{admin_id}",
         json={"name": updated_name},
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -112,7 +108,7 @@ def test_update_admin_name(
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
 
-    assert data["id"] == admin_id
+    assert data["id"] == test_admin_object["id"]
     assert data["name"] == updated_name
     assert data["email"] == test_admin_object["email"]
 

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -80,11 +80,8 @@ async def test_get_all_admins(mock_mediator_call, mock_get_admin_by_email, clien
 
 @pytest.mark.asyncio
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_by_email, client):
+async def test_update_admin_success(mock_get_object, client):
     """Test successful admin name update."""
-    # Mock auth user lookup
-    mock_get_by_email.return_value = test_admin_object
-    
     # Mock existing admin
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
@@ -92,14 +89,6 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_
         'email': test_admin_object['email']
     })()
     mock_get_object.return_value = mock_admin
-    
-    # Mock updated admin
-    updated_admin = type('MockAdmin', (), {
-        'id': test_admin_object['id'],
-        'name': 'Updated Name',
-        'email': test_admin_object['email']
-    })()
-    mock_write_to_db.return_value = updated_admin
 
     token = create_access_token(test_admin_object["email"])
     response = client.post(
@@ -117,10 +106,8 @@ async def test_update_admin_success(mock_write_to_db, mock_get_object, mock_get_
 
 @pytest.mark.asyncio
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client):
+async def test_update_admin_not_found(mock_get_object, client):
     """Test update admin when admin not found."""
-    # Mock auth user lookup
-    mock_get_by_email.return_value = test_admin_object
     mock_get_object.return_value = None
 
     token = create_access_token(test_admin_object["email"])
@@ -136,18 +123,15 @@ async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client
 
 @pytest.mark.asyncio
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
-async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_email, client):
+async def test_update_admin_empty_name(mock_get_object, client):
     """Test update admin with empty name."""
-
-    mock_get_email.return_value = test_admin_object
-    
+    # Mock existing admin
     mock_admin = type('MockAdmin', (), {
         'id': test_admin_object['id'],
         'name': test_admin_object['name'],
         'email': test_admin_object['email']
     })()
     mock_get_object.return_value = mock_admin
-    mock_write_to_db.return_value = mock_admin
 
     token = create_access_token(test_admin_object["email"])
     response = client.post(
@@ -156,5 +140,4 @@ async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_g
         headers={"Authorization": f"Bearer {token}"}
     )
 
- 
     assert response.status_code == 200


### PR DESCRIPTION
This PR introduces a new endpoint that allows updating the name field of an admin using their admin_id. A Pydantic schema has been created to support this functionality, with future extensibility in mind.

**🎯 Key Changes**
✅ Added a new POST /api/admin/{admin_id} endpoint to update the admin's name

✅ Created a dedicated Pydantic schema for the update request

✅ Wrote unit tests to verify successful updates and error handling

✅ Verified that both endpoint and tests function correctly

**issue number : 872**
