### PR TITLE
Fix Typo: Rename settingIntergrationData to settingIntegrationData in Mock Data

### DIFF
--- a/margin/margin_frontend/admin_template/demo/src/mock/mock.ts
+++ b/margin/margin_frontend/admin_template/demo/src/mock/mock.ts
@@ -24,7 +24,7 @@ import {
 } from './data/cryptoData'
 import {
     settingData,
-    settingIntergrationData,
+    settingIntegrationData,
     settingBillingData,
     invoiceData,
     logData,
@@ -67,7 +67,7 @@ export function mockServer({ environment = 'test' }) {
                 ordersData,
                 orderDetailsData,
                 settingData,
-                settingIntergrationData,
+                settingIntegrationData,
                 settingBillingData,
                 invoiceData,
                 logData,


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the variable name settingIntergrationData, changing it to the correct settingIntegrationData in both the import statement and the mockServer function export within mock.ts. This change improves code readability and consistency. No functional changes were made.