### PR TITLE
fix: admin reset password logic

### DIFF
--- a/margin/margin_app/app/api/admin.py
+++ b/margin/margin_app/app/api/admin.py
@@ -1,5 +1,9 @@
 """
 API endpoints for admin management.
+
+This module provides REST API endpoints for admin user management including
+creation, retrieval, password reset, and profile updates. All endpoints
+except password reset require authentication.
 """
 
 from typing import Optional
@@ -14,11 +18,10 @@ from app.crud.admin import admin_crud
 from app.schemas.admin import (
     AdminRequest,
     AdminResponse,
-    AdminResetPassword,
     AdminGetAllResponse,
-    AdminUpdateRequest
+    AdminUpdateRequest,
 )
-from app.services.auth.base import get_admin_user_from_state
+from app.services.auth.base import get_admin_user_from_state, get_current_user
 from app.services.auth.security import get_password_hash, verify_password
 from app.services.emails import email_service
 from fastapi.responses import JSONResponse
@@ -34,10 +37,7 @@ router = APIRouter(prefix="")
     summary="add a new admin",
     description="Adds a new admin in the application",
 )
-async def add_admin(
-    data: AdminRequest,
-    request: Request
-) -> AdminResponse:
+async def add_admin(data: AdminRequest, request: Request) -> AdminResponse:
     """
     Add a new admin with the provided admin data.
 
@@ -56,8 +56,7 @@ async def add_admin(
 
     if not current_admin:
         raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication required"
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required"
         )
 
     if not current_admin.is_super_admin:
@@ -66,15 +65,12 @@ async def add_admin(
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only superadmins can create new admin users"
+            detail="Only superadmins can create new admin users",
         )
 
     try:
         new_admin = await admin_crud.create_admin(
-            email=data.email,
-            name=data.name,
-            password=None,
-            is_super_admin=False
+            email=data.email, name=data.name, password=None, is_super_admin=False
         )
 
     except IntegrityError as e:
@@ -182,37 +178,67 @@ async def change_password(
 
 
 @router.post(
-    "/reset_password/{token}",
+    "/reset_password/{reset_token}",
     status_code=status.HTTP_200_OK,
     summary="password reset for admin",
-    description="change password for admin",
+    description="Reset password for admin using token",
 )
-async def reset_password(data: AdminResetPassword, token: str):
+async def reset_password(
+    reset_token: str, new_password: str = Query(..., min_length=1)
+):
     """
-    Reset the password for an admin user.
-    This function verifies the provided old password, updates the password
-    to a new one if the verification is successful, and saves the changes
-    to the database.
+    Reset admin password using a secure reset token.
+
+    This endpoint allows admin users to reset their password using a valid
+    reset token received via email. The token is verified, the admin is
+    retrieved, and their password is securely hashed and updated.
+
     Args:
-        data (AdminResetPassword): An object containing the old and new passwords.
-        token (str): The authentication token of the current admin user.
-    Raises:
-        HTTPException: If the provided old password does not match the stored password.
+        reset_token: JWT token containing admin email and expiration.
+        new_password: New password with minimum length of 1 character.
+
     Returns:
-        JSONResponse: A response indicating that the password was successfully changed.
+        JSONResponse: Success message indicating password was reset.
+
+    Raises:
+        HTTPException: 400 for invalid/expired tokens, 404 for admin not found,
+                      500 for server errors.
     """
+    try:
+        admin = await get_current_user(reset_token)
 
-    admin = await get_admin_user_from_state(token=token)
+        if not admin:
+            logger.error("Admin not found for the provided token")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Admin not found",
+            )
 
-    if not verify_password(data.old_password, admin.password):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="The provided old password does not match",
-        )
+        admin.password = get_password_hash(new_password)
+        await admin_crud.write_to_db(admin)
 
-    admin.password = get_password_hash(data.new_password)
-    await admin_crud.write_to_db(admin)
-    return JSONResponse(content={"message": "Password was changed"})
+        logger.info(f"Password successfully reset for admin: {admin.email}")
+        return JSONResponse(content={"message": "Password was successfully reset"})
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error during password reset: {str(e)}")
+        if "expired" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Reset token has expired",
+            )
+        elif "invalid" in str(e).lower():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid reset token",
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="An error occurred while resetting the password",
+            )
 
 
 @router.put(

--- a/margin/margin_app/app/main.py
+++ b/margin/margin_app/app/main.py
@@ -103,7 +103,16 @@ async def auth_admin_user(request: Request, call_next):
     """
     if not request.url.path.startswith("/api/admin"):
         return await call_next(request)
+    
+    public_endpoints = [
+        "/api/admin/reset_password/",
+        "/api/admin/change_password"
+    ]
 
+    for endpoint in public_endpoints:
+        if request.url.path.startswith(endpoint):
+            return await call_next(request)
+        
     try:
         auth_header = request.headers.get("Authorization")
         if not auth_header:

--- a/margin/margin_app/app/schemas/admin.py
+++ b/margin/margin_app/app/schemas/admin.py
@@ -1,5 +1,8 @@
 """
-This module contains Pydantic schemas for admin.
+Pydantic schemas for admin user management.
+
+This module defines request and response models for admin-related API endpoints,
+including validation rules and serialization configurations.
 """
 
 from uuid import UUID
@@ -32,10 +35,13 @@ class AdminRequest(AdminBase):
 
 class AdminResetPassword(BaseSchema):
     """
-    Admin reset password model
+    Schema for token-based admin password reset.
+
+    This schema is used when an admin user resets their password
+    using a secure reset token received via email. Only requires
+    the new password as the identity is verified through the token.
     """
 
-    old_password: str
     new_password: str
 
 
@@ -59,6 +65,7 @@ class AdminUpdateRequest(BaseSchema):
     """
     Admin update request model (for updating admin fields)
     """
+
     name: Optional[str] = None
 
 

--- a/margin/margin_app/app/services/auth/base.py
+++ b/margin/margin_app/app/services/auth/base.py
@@ -40,7 +40,9 @@ def decode_signup_token(token: str) -> str:
     - Exception("Token expired"): if token has expired
     """
     try:
-        payload = jwt.decode(token, settings.secret_key, algorithms=[settings.algorithm])
+        payload = jwt.decode(
+            token, settings.secret_key, algorithms=[settings.algorithm]
+        )
         email = payload.get("sub")
         if email is None:
             raise Exception("Invalid token")
@@ -85,7 +87,7 @@ def create_refresh_token(email: str, expires_delta: timedelta | None = None):
     to_encode = {
         "sub": email,
         "exp": expire,
-     }
+    }
     return jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
 
 
@@ -117,6 +119,24 @@ async def get_current_user(token: str) -> Admin:
         return user
     except InvalidTokenError as e:
         raise Exception("jwt expired") from e
+
+
+async def create_reset_password_token(email: str) -> str:
+    """
+    Creates a password reset token for the given email address.
+
+    This function generates a JWT token with a specific expiration time
+    for password reset purposes. The token contains the user's email
+    and expires after the configured reset password time.
+
+    Args:
+        email: The email address of the admin user requesting password reset.
+
+    Returns:
+        A JWT token string that can be used for password reset verification.
+    """
+    expires_delta = timedelta(minutes=settings.reset_password_expire_minutes)
+    return create_access_token(email, expires_delta)
 
 
 class GoogleAuth:

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -1,5 +1,8 @@
 """
-Unit tests for Admin API endpoints using function-based approach without async/await.
+Unit tests for Admin API endpoints.
+
+Comprehensive test suite covering admin management functionality including
+user creation, password reset, and profile updates.
 """
 
 import uuid
@@ -88,7 +91,7 @@ def mock_get_all_admin():
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client):
     """Test update admin when admin not found."""
-    
+
     mock_get_by_email.return_value = make_admin_obj(test_admin_object)
     mock_get_object.return_value = None
 
@@ -96,7 +99,7 @@ async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client
     response = client.put(
         f"{ADMIN_URL}{test_admin_object['id']}",
         json={"name": "Updated Name"},
-        headers={"Authorization": f"Bearer {token}"}
+        headers={"Authorization": f"Bearer {token}"},
     )
 
     assert response.status_code == 404
@@ -107,11 +110,13 @@ async def test_update_admin_not_found(mock_get_object, mock_get_by_email, client
 @patch("app.crud.admin.admin_crud.get_by_email", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.get_object", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
-async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_get_email, client):
+async def test_update_admin_empty_name(
+    mock_write_to_db, mock_get_object, mock_get_email, client
+):
     """Test update admin with empty name."""
-  
+
     mock_get_email.return_value = make_admin_obj(test_admin_object)
-    
+
     mock_admin = make_admin_obj(test_admin_object)
     mock_get_object.return_value = mock_admin
     mock_write_to_db.return_value = mock_admin
@@ -120,11 +125,11 @@ async def test_update_admin_empty_name(mock_write_to_db, mock_get_object, mock_g
     response = client.put(
         f"{ADMIN_URL}{test_admin_object['id']}",
         json={"name": ""},
-        headers={"Authorization": f"Bearer {token}"}
+        headers={"Authorization": f"Bearer {token}"},
     )
 
-    
     assert response.status_code == 200
+
 
 @patch("app.api.admin.get_admin_user_from_state", new_callable=AsyncMock)
 @patch("app.crud.admin.admin_crud.create_admin", new_callable=AsyncMock)
@@ -254,3 +259,179 @@ def test_name_optional(
         headers={"Authorization": f"Bearer {token}"},
     )
     assert response.status_code == 201
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
+def test_reset_password_success(mock_write_to_db, mock_get_current_user, client):
+    """Test successful password reset with valid token."""
+    mock_admin = make_admin_obj(test_admin_object)
+    mock_get_current_user.return_value = mock_admin
+    mock_write_to_db.return_value = mock_admin
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/valid_token?new_password=newSecurePassword123!"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Password was successfully reset"
+    mock_get_current_user.assert_called_once_with("valid_token")
+    mock_write_to_db.assert_called_once()
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+def test_reset_password_invalid_token(mock_get_current_user, client):
+    """Test password reset with invalid token."""
+    mock_get_current_user.side_effect = Exception("Invalid jwt")
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/invalid_token?new_password=newSecurePassword123!"
+    )
+
+    assert response.status_code == 400
+    assert "Invalid reset token" in response.json()["detail"]
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+def test_reset_password_expired_token(mock_get_current_user, client):
+    """
+    Test password reset with expired token.
+    """
+    mock_get_current_user.side_effect = Exception("jwt expired")
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/expired_token?new_password=newSecurePassword123!"
+    )
+
+    assert response.status_code == 400
+    assert "Reset token has expired" in response.json()["detail"]
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+def test_reset_password_admin_not_found(mock_get_current_user, client):
+    """
+    Test password reset when admin is not found for valid token.
+    """
+    mock_get_current_user.return_value = None
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/valid_token?new_password=newSecurePassword123!"
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Admin not found"
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
+def test_reset_password_database_error(mock_write_to_db, mock_get_current_user, client):
+    """
+    Test password reset when database write fails.
+    """
+    mock_admin = make_admin_obj(test_admin_object)
+    mock_get_current_user.return_value = mock_admin
+    mock_write_to_db.side_effect = Exception("Database error")
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/valid_token?new_password=newSecurePassword123!"
+    )
+
+    assert response.status_code == 500
+    assert "An error occurred while resetting the password" in response.json()["detail"]
+
+
+def test_reset_password_missing_new_password(client):
+    """Test password reset without providing new_password field."""
+    response = client.post(f"{ADMIN_URL}reset_password/valid_token")
+
+    assert response.status_code == 422
+
+
+def test_reset_password_empty_new_password(client):
+    """Test password reset with empty new_password."""
+    response = client.post(f"{ADMIN_URL}reset_password/valid_token?new_password=")
+
+    assert response.status_code == 422
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
+@patch("app.api.admin.get_password_hash")
+def test_reset_password_password_hashing(
+    mock_get_password_hash, mock_write_to_db, mock_get_current_user, client
+):
+    """Test that password is properly hashed during reset."""
+    mock_admin = make_admin_obj(test_admin_object)
+    mock_get_current_user.return_value = mock_admin
+    mock_write_to_db.return_value = mock_admin
+    mock_get_password_hash.return_value = "hashed_password"
+
+    new_password = "newSecurePassword123!"
+    response = client.post(
+        f"{ADMIN_URL}reset_password/valid_token?new_password={new_password}"
+    )
+
+    assert response.status_code == 200
+    mock_get_password_hash.assert_called_once_with(new_password)
+    assert mock_admin.password == "hashed_password"
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
+def test_reset_password_extra_fields_ignored(
+    mock_write_to_db, mock_get_current_user, client
+):
+    """Test that reset password endpoint ignores extra query parameters."""
+    mock_admin = make_admin_obj(test_admin_object)
+    mock_get_current_user.return_value = mock_admin
+    mock_write_to_db.return_value = mock_admin
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/valid_token?new_password=newSecurePassword123!&extra_field=ignored&another=param"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Password was successfully reset"
+
+
+@patch("app.api.admin.get_current_user", new_callable=AsyncMock)
+@patch("app.crud.admin.admin_crud.write_to_db", new_callable=AsyncMock)
+def test_reset_password_different_admin_tokens(
+    mock_write_to_db, mock_get_current_user, client
+):
+    """Test password reset works for different admin users."""
+    admin1 = make_admin_obj(
+        {
+            "id": str(uuid.uuid4()),
+            "email": "admin1@test.com",
+            "name": "Admin One",
+            "is_super_admin": False,
+        }
+    )
+
+    mock_get_current_user.return_value = admin1
+    mock_write_to_db.return_value = admin1
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/token1?new_password=newPassword1"
+    )
+
+    assert response.status_code == 200
+
+    admin2 = make_admin_obj(
+        {
+            "id": str(uuid.uuid4()),
+            "email": "admin2@test.com",
+            "name": "Admin Two",
+            "is_super_admin": True,
+        }
+    )
+
+    mock_get_current_user.return_value = admin2
+    mock_write_to_db.return_value = admin2
+
+    response = client.post(
+        f"{ADMIN_URL}reset_password/token2?new_password=newPassword2"
+    )
+
+    assert response.status_code == 200

--- a/margin/margin_app/app/tests/api/test_admin_api.py
+++ b/margin/margin_app/app/tests/api/test_admin_api.py
@@ -386,9 +386,10 @@ def test_reset_password_extra_fields_ignored(
     mock_get_current_user.return_value = mock_admin
     mock_write_to_db.return_value = mock_admin
 
-    response = client.post(
-        f"{ADMIN_URL}reset_password/valid_token?new_password=newSecurePassword123!&extra_field=ignored&another=param"
-    )
+    base_url = f"{ADMIN_URL}reset_password/valid_token"
+    query_params = "?new_password=newSecurePassword123!&extra_field=ignored&another=param"
+    
+    response = client.post(f"{base_url}{query_params}")
 
     assert response.status_code == 200
     assert response.json()["message"] == "Password was successfully reset"


### PR DESCRIPTION
This PR:


- updates `reset_password` endpoint to accept only `new_password` parameter
- implements jwt token verification with email extraction
- adds password reset endpoints to middleware exclusions in `main.py`
- adds comprehensive test cases for password reset


close #916 

