### PR TITLE
add: add notification bot to compose

### DIFF
--- a/devops/docker-compose.margin.yml
+++ b/devops/docker-compose.margin.yml
@@ -46,12 +46,22 @@ services:
     volumes:
       - ../margin/margin_frontend:/src
       - node_modules:/src/node_modules
-    env_file:
-      - ../margin/margin_frontend/.env
+    # env_file:
+    #   - ../margin/margin_frontend/.env
     ports:
       - "5173:5173"
     depends_on:
       - backend
+
+  notification_bot:
+    build:
+      context: ../margin/margin_app
+      dockerfile: app/telegram/Dockerfile
+    restart: always
+    depends_on:
+      - backend
+    networks:
+      - app_network
 
 volumes:
   pgdata: {}

--- a/margin/margin_app/app/telegram/Dockerfile
+++ b/margin/margin_app/app/telegram/Dockerfile
@@ -1,6 +1,14 @@
 FROM python:3.12-slim
+
 WORKDIR /app
-COPY ../../pyproject.toml ../../poetry.lock ./
+
+# Copy poetry files from root of context
+COPY pyproject.toml poetry.lock ./
+
+# Install dependencies
 RUN pip install poetry && poetry install --no-root
-COPY . .
+
+# Copy the telegram bot code from telegram folder
+COPY app/telegram ./telegram
+
 CMD ["python", "-m", "telegram.main"]

--- a/margin/margin_app/scripts/entrypoint.sh
+++ b/margin/margin_app/scripts/entrypoint.sh
@@ -1,4 +1,5 @@
 echo "Run migration with alembic"
+source /src/.venv/bin/activate
 poetry run alembic upgrade head
 
 echo "Starting the server ..."


### PR DESCRIPTION
This PR Closes #914 with the following updates:

Added notification_bot service to docker-compose.margin.yml using a custom Dockerfile in the telegram directory with proper build context.
although the build was successful, i think the reviewer needs to also see the full logs, here it is: 

dannys@dannys-HP-EliteBook-840-G3:~/spotnet/devops$ docker-compose -f docker-compose.margin.yml up --build
[+] Building 18.4s (35/35) FINISHED                                                                                                                                                                 docker:default
 => [backend internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 730B                                                                                                                                                                          0.0s
 => [notification_bot internal] load metadata for docker.io/library/python:3.12-slim                                                                                                                         12.3s
 => [backend auth] library/python:pull token for registry-1.docker.io                                                                                                                                         0.0s
 => [backend internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 63B                                                                                                                                                                              0.0s
 => [backend internal] load build context                                                                                                                                                                     3.8s
 => => transferring context: 120.14MB                                                                                                                                                                         3.8s
 => [notification_bot 1/5] FROM docker.io/library/python:3.12-slim@sha256:4600f71648e110b005bf7bca92dbb335e549e6b27f2e83fceee5e11b3e1a4d01                                                                    0.0s
 => CACHED [backend 2/7] RUN apt-get update     && apt-get install -y --no-install-recommends        libpq-dev gcc g++ make libffi-dev build-essential        curl     && rm -rf /var/lib/apt/lists/*         0.0s
 => CACHED [backend 3/7] RUN curl -sSL https://install.python-poetry.org | python3 -                                                                                                                          0.0s
 => CACHED [backend 4/7] WORKDIR /src                                                                                                                                                                         0.0s
 => CACHED [backend 5/7] COPY . /src/                                                                                                                                                                         0.0s
 => CACHED [backend 6/7] RUN poetry config virtualenvs.create false     && poetry install --no-interaction --no-root                                                                                          0.0s
 => CACHED [backend 7/7] RUN chmod +x /src/scripts/entrypoint.sh                                                                                                                                              0.0s
 => [backend] exporting to image                                                                                                                                                                              0.1s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:ad824d24738317eb77bb8a44b7889abc356cfe2421c8db3f511e27cc1cbb8367                                                                                                                  0.0s
 => => naming to docker.io/library/devops-backend                                                                                                                                                             0.0s
 => [backend] resolving provenance for metadata file                                                                                                                                                          0.0s
 => [notification_bot internal] load build definition from Dockerfile                                                                                                                                         0.0s
 => => transferring dockerfile: 346B                                                                                                                                                                          0.0s
 => [frontend internal] load build definition from Dockerfile                                                                                                                                                 0.0s
 => => transferring dockerfile: 238B                                                                                                                                                                          0.0s
 => [frontend internal] load metadata for docker.io/library/node:23-slim                                                                                                                                      1.8s
 => [frontend auth] library/node:pull token for registry-1.docker.io                                                                                                                                          0.0s
 => [notification_bot internal] load .dockerignore                                                                                                                                                            0.0s
 => => transferring context: 63B                                                                                                                                                                              0.0s
 => [notification_bot internal] load build context                                                                                                                                                            0.3s
 => => transferring context: 614B                                                                                                                                                                             0.3s
 => CACHED [notification_bot 2/5] WORKDIR /app                                                                                                                                                                0.0s
 => CACHED [notification_bot 3/5] COPY pyproject.toml poetry.lock ./                                                                                                                                          0.0s
 => CACHED [notification_bot 4/5] RUN pip install poetry && poetry install --no-root                                                                                                                          0.0s
 => CACHED [notification_bot 5/5] COPY app/telegram ./telegram                                                                                                                                                0.0s
 => [notification_bot] exporting to image                                                                                                                                                                     0.2s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:23560ecd4346bec62b15e738f4b21a61fc29d8e36a8dd99b9950976bbae49c52                                                                                                                  0.2s
 => => naming to docker.io/library/devops-notification_bot                                                                                                                                                    0.0s
 => [notification_bot] resolving provenance for metadata file                                                                                                                                                 0.0s
 => [frontend internal] load .dockerignore                                                                                                                                                                    0.0s
 => => transferring context: 67B                                                                                                                                                                              0.0s
 => [frontend 1/5] FROM docker.io/library/node:23-slim@sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a                                                                                0.0s
 => [frontend internal] load build context                                                                                                                                                                    0.3s
 => => transferring context: 237.66kB                                                                                                                                                                         0.2s
 => CACHED [frontend 2/5] WORKDIR /src                                                                                                                                                                        0.0s
 => CACHED [frontend 3/5] COPY ./package.json ./package-lock.json .                                                                                                                                           0.0s
 => CACHED [frontend 4/5] RUN npm install                                                                                                                                                                     0.0s
 => CACHED [frontend 5/5] COPY . .                                                                                                                                                                            0.0s
 => [frontend] exporting to image                                                                                                                                                                             0.0s
 => => exporting layers                                                                                                                                                                                       0.0s
 => => writing image sha256:347bd791d7b8160bf448b585d3141d482d5191550452c4327aabb4a6db86cdb1                                                                                                                  0.0s
 => => naming to docker.io/library/devops-frontend                                                                                                                                                            0.0s
 => [frontend] resolving provenance for metadata file                                                                                                                                                         0.0s
[+] Running 4/4
 ✔ Container devops-db-1                Created                                                                                                                                                               0.0s 
 ✔ Container devops-frontend-1          Recreated                                                                                                                                                             0.6s 
 ✔ Container devops-notification_bot-1  Created                                                                                                                                                               0.0s 
 ✔ Container devops-backend-1           Recreated                                                                                                                                                             0.4s 
Attaching to backend-1, db-1, frontend-1, notification_bot-1
db-1                | 
db-1                | PostgreSQL Database directory appears to contain a database; Skipping initialization
db-1                | 
db-1                | 2025-07-04 02:00:50.917 UTC [1] LOG:  starting PostgreSQL 17.5 (Debian 17.5-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
db-1                | 2025-07-04 02:00:50.919 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
db-1                | 2025-07-04 02:00:50.919 UTC [1] LOG:  listening on IPv6 address "::", port 5432
db-1                | 2025-07-04 02:00:50.948 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
db-1                | 2025-07-04 02:00:51.015 UTC [29] LOG:  database system was shut down at 2025-07-04 01:36:07 UTC
backend-1           | Run migration with alembic
db-1                | 2025-07-04 02:00:51.197 UTC [1] LOG:  database system is ready to accept connections
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 0
frontend-1          | 
frontend-1          | > margin_frontend@0.0.0 dev
frontend-1          | > vite --host
frontend-1          | 
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 0
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
backend-1           | The virtual environment found in /home/dannys/spotnet/margin/margin_app/.venv seems to be broken.
backend-1           | Recreating virtualenv starkhero in /src/.venv
notification_bot-1 exited with code 1
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
backend-1           | Command not found: alembic
notification_bot-1 exited with code 1
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 0
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
frontend-1          | 
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
frontend-1          | ♻️  Generating routes...
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1 exited with code 1
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
frontend-1          | ✅ Processed routes in 709ms
frontend-1          | 
frontend-1          |   VITE v6.2.3  ready in 6862 ms
frontend-1          | 
frontend-1          |   ➜  Local:   http://localhost:5173/
frontend-1          |   ➜  Network: http://172.21.0.2:5173/
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
backend-1 exited with code 0
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
db-1                | 2025-07-04 02:05:51.112 UTC [27] LOG:  checkpoint starting: time
db-1                | 2025-07-04 02:05:51.135 UTC [27] LOG:  checkpoint complete: wrote 3 buffers (0.0%); 0 WAL file(s) added, 0 removed, 0 recycled; write=0.008 s, sync=0.003 s, total=0.023 s; sync files=2, longest=0.002 s, average=0.002 s; distance=0 kB, estimate=0 kB; lsn=0/1939360, redo lsn=0/1939308
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Run migration with alembic
notification_bot-1  | Traceback (most recent call last):
notification_bot-1  |   File "<frozen runpy>", line 198, in _run_module_as_main
notification_bot-1  |   File "<frozen runpy>", line 88, in _run_code
notification_bot-1  |   File "/app/telegram/main.py", line 4, in <module>
notification_bot-1  |     from aiogram import Bot, Dispatcher
notification_bot-1  | ModuleNotFoundError: No module named 'aiogram'
notification_bot-1 exited with code 1
backend-1           | Command not found: alembic
backend-1           | Starting the server ...
backend-1           | /src/scripts/entrypoint.sh: line 6: uvicorn: command not found
backend-1 exited with code 127

w Enable Watch

and also here is the build success screenshot 
![image](https://github.com/user-attachments/assets/13814498-9d3a-4aeb-bffc-88caddf8ef20)

![image](https://github.com/user-attachments/assets/ad0e4216-dcbc-46df-9338-785682c5fb38)
