### PR TITLE
feat(telegram): implemented assets handler

### DIFF
--- a/margin/margin_app/.env.dev
+++ b/margin/margin_app/.env.dev
@@ -1,5 +1,6 @@
 APP_ENV=development
 SECRET_KEY=SECRET_KEY
+API_BASE_URL=http://localhost:8000/api/v1
 
 # Database creds
 POSTGRES_USER=user

--- a/margin/margin_app/app/telegram/api/admin.py
+++ b/margin/margin_app/app/telegram/api/admin.py
@@ -1,0 +1,19 @@
+import aiohttp
+from app.telegram.config import BotConfig
+
+config = BotConfig()
+
+async def get_assets_statistics():
+    """
+    Fetch assets statistics from the backend `/admin/statistic/assets` endpoint.
+    """
+    url = f"{config.API_BASE_URL}/admin/statistic/assets"
+    headers = {
+        "Accept": "application/json"
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers=headers) as resp:
+            if resp.status != 200:
+                raise Exception(f"Backend returned status {resp.status}")
+            return await resp.json()

--- a/margin/margin_app/app/telegram/config.py
+++ b/margin/margin_app/app/telegram/config.py
@@ -10,6 +10,7 @@ class BotConfig(BaseSettings):
     """Bot configuration loaded from environment variables."""
     BOT_API_KEY: str = Field(..., alias="BOT_API_KEY")
     ADMINS: List[int] = Field(..., alias="ADMINS")
+    API_BASE_URL: str = Field(..., alias="API_BASE_URL")
 
     model_config = SettingsConfigDict(
         env_file=".env.dev",

--- a/margin/margin_app/app/telegram/handlers/admin.py
+++ b/margin/margin_app/app/telegram/handlers/admin.py
@@ -1,0 +1,44 @@
+""" Inside, add a handler called /assets. Use the Admin Filter from this issue to verify the user is an admin. Then, call the Assets statistic method from this issue to retrieve the data. Format the response using Telegram Markdown so it displays neatly.""""
+from aiogram import Router, types
+from aiogram.filters import Command
+from aiogram.utils.formatting import Bold, Code, as_list, as_marked_section
+
+from app.telegram.filters.admin_filter import AdminFilter
+from app.telegram.api.admin import get_assets_statistics
+
+router = Router()
+router.message.filter(AdminFilter())
+
+@router.message(Command("assets"))
+async def assets_handler(message: types.Message):
+    """
+    Responds with the assets statistics if the user is an admin.
+    """
+    try:
+        stats = await get_assets_statistics()
+        breakdown = []
+        for asset in stats["assets"]:
+            breakdown.append(
+                f"{asset['token']}: {asset['amount']} units (${asset['value']:,})"
+            )
+
+        text = as_list(
+            Bold("Asset Statistics"),
+            Bold(f"Total Value: ${stats['total_value']:,}"),
+            as_marked_section(
+                Bold("Breakdown by Token:"),
+                *breakdown,
+                marker="•"
+            )
+        )
+
+        await message.answer(**text.as_kwargs())
+       
+    except Exception as e:
+        error_text = as_list(
+            Bold("Failed to fetch asset statistics"),
+            Code(str(e))
+        )
+        await message.answer(**error_text.as_kwargs())
+
+


### PR DESCRIPTION
## summary
This PR adds the /assets Telegram bot command to allow administrators to view asset statistics directly in Telegram.
The command is restricted to admin users via the existing AdminFilter and retrieves statistics from the backend /admin/statistic/assets endpoint.

closes #917 